### PR TITLE
OOT: Small MQ Spirit logic fix

### DIFF
--- a/packages/core/data/oot/world_mq/spirit_temple_mq.yml
+++ b/packages/core/data/oot/world_mq/spirit_temple_mq.yml
@@ -40,7 +40,7 @@
     "Spirit Temple Child Upper": "has(SMALL_KEY_SPIRIT, 7)"
     "Spirit Temple Sun Block Room": "is_adult || can_play(SONG_TIME)" #Adult's long legs make the jumps easy
     "Spirit Temple Adult Lower": "has_fire_arrows && has_mirror_shield"
-    "Spirit Temple Adult Upper": "has(SMALL_KEY_SPIRIT, 5)"
+    "Spirit Temple Adult Upper": "is_adult && has(SMALL_KEY_SPIRIT, 5)"
     "Spirit Temple Boss": "event(SPIRIT_TEMPLE_LIGHT) && has_mirror_shield && has(BOSS_KEY_SPIRIT)"
   events:
     SPIRIT_STATUE_FIRE: "has_fire" #This allows for adult to open the shortcut for kid with Fire Arrows.


### PR DESCRIPTION
Fixes logic so that only adult can reach the upper portions of adult spirit.