### PR TITLE
Fix windmill hp trick

### DIFF
--- a/packages/core/data/oot/world/overworld.yml
+++ b/packages/core/data/oot/world/overworld.yml
@@ -714,7 +714,7 @@
   events:
     WELL_DRAIN: "is_child && can_play(SONG_STORMS)"
   locations:
-    "Windmill HP": "can_boomerang || event(WINDMILL_TOP) || trick(OOT_WINDMILL_HP_NOTHING)"
+    "Windmill HP": "can_boomerang || event(WINDMILL_TOP) || (is_adult && trick(OOT_WINDMILL_HP_NOTHING))"
     "Windmill Song of Storms": "is_adult && has(OCARINA)"
 "Kakariko Carpenter House":
   region: KAKARIKO


### PR DESCRIPTION
Brought up in the discord, during some recent refactors the adult check was accidentally removed from this trick. This re-adds the adult check to this.