### PR TITLE
MM: Various speedups

### DIFF
--- a/packages/core/src/mm/actors/En/En_Akindonuts.S
+++ b/packages/core/src/mm/actors/En/En_Akindonuts.S
@@ -41,3 +41,12 @@ PATCH_END
 PATCH_START 0x80bed014
   nop
 PATCH_END
+
+/* Disable the flying away cutscene lock */
+PATCH_START 0x80BEF6B8
+  nop
+PATCH_END
+
+PATCH_START 0x80ADC4FC
+  nop
+PATCH_END

--- a/packages/core/src/mm/actors/En/En_Geg.S
+++ b/packages/core/src/mm/actors/En/En_Geg.S
@@ -4,3 +4,52 @@
 PATCH_START 0x80bb31e0
   li t7,0xff
 PATCH_END
+
+/* Cutscene QoLs */
+PATCH_START 0x80BB2398
+  nop
+PATCH_END
+
+PATCH_START 0x80BB340C
+  lh      t8, 0x04AA(s0)
+  addiu   t8, t8, -0x0001
+  sh      t8, 0x04AA(s0)
+PATCH_END
+
+PATCH_START 0x80BB3420
+  bnez    t8, .+0x28
+PATCH_END
+
+PATCH_START 0x80BB2598
+  jal     DonGero_StartCutscene
+PATCH_END
+
+PATCH_START 0x80BB332C
+  jal     DonGero_GetRollTarget
+  lh      a0, 0x04D8 (s0)
+  beqz    v0, .+0xE0
+  nop
+  addiu   a0, s0, 0x0024
+  move    a1, v0
+  nop
+  nop
+  nop
+  nop
+PATCH_END
+
+PATCH_START 0x80BB3360
+  jal     DonGero_GetRollTarget
+  lh      a0, 0x04D8 (s0)
+  move    a1, v0
+  nop
+  nop
+  nop
+  nop
+PATCH_END
+
+PATCH_START 0x80BB4428
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000
+PATCH_END

--- a/packages/core/src/mm/actors/En/En_Geg.c
+++ b/packages/core/src/mm/actors/En/En_Geg.c
@@ -22,3 +22,60 @@ int EnGeg_GiveItem(Actor* actor, GameState_Play* play, s16 gi, float a, float b)
 }
 
 PATCH_CALL(0x80bb3290, EnGeg_GiveItem);
+
+/**
+ * Add new points for Hungry Goron to roll on
+ **/
+static Vec3f rollTargets[6] = {
+    {
+        .x = -550,
+        .y = 8,
+        .z = 550
+    },
+    {
+        .x = 220,
+        .y = 43,
+        .z = 525
+    },
+    {
+        .x = 960,
+        .y = 90,
+        .z = 525
+    },
+    {
+        .x = 2060,
+        .y = 16,
+        .z = 925
+    },
+    {
+        .x = 2710,
+        .y = -40,
+        .z = 1980
+    },
+    {
+        .x = 3510,
+        .y = -90,
+        .z = 2380
+    }
+};
+
+/**
+ * Hook function used to get the roll target position of the goron.
+ **/
+Vec3f* DonGero_GetRollTarget(s16 index) {
+    if (index < 6) {
+        return &rollTargets[index];
+    }
+    return NULL;
+}
+
+/**
+ * Hook function used to override starting the cutscene.
+ **/
+void DonGero_StartCutscene(s16 index, Actor* actor) {
+    if (index == 0x17) {   
+        u8* address = (u8*)actor;
+        u16* rollingAddress = (u16*)(address + 0x4AA);
+        *rollingAddress = 0x180;
+    } 
+}

--- a/packages/core/src/mm/actors/En/En_Sellnuts.S
+++ b/packages/core/src/mm/actors/En/En_Sellnuts.S
@@ -4,3 +4,12 @@
 PATCH_START 0x80add204
   nop
 PATCH_END
+
+/* Faster TF fly path and disable the flying away cutscene lock */
+PATCH_START 0x80ADC4FC
+  nop
+PATCH_END
+
+PATCH_START 0x80ADD200
+  li t8,4
+PATCH_END

--- a/packages/core/src/mm/actors/En/En_Test7.S
+++ b/packages/core/src/mm/actors/En/En_Test7.S
@@ -31,3 +31,8 @@ PATCH_START 0x80af2350 + 0x68
   move    a1, s1
   beqz    t9, . + 0x14 /* 0x80AF2350 + 0x88 */
 PATCH_END
+
+/* Allow skip soaring cutscene on button press */ 
+PATCH_START 0x80AF1AF6
+.half 0x2350 /* Replaces .half 0x1CA0 */
+PATCH_END


### PR DESCRIPTION
### Added:
* MM: all scrubs no longer lock you in place when they're leaving (exception being Clock Town one, due to a special handling)
* MM: The Soaring cutscene of the wings wrapping Link can be skipped by pressing any **button**
* MM: Hungry Goron no longer locks you in place when rolling away

All these are listed in #182 
