### PR TITLE
BtW Logic Fixes and Enhancements

### DIFF
--- a/packages/core/data/mm/macros.yml
+++ b/packages/core/data/mm/macros.yml
@@ -78,7 +78,7 @@
 "has_rupees": "event(RUPEES)"
 "has_zora_egg": "event(ZORA_EGGS_HOOKSHOT_ROOM) || event(ZORA_EGGS_BARREL_MAZE) || event(ZORA_EGGS_LONE_GUARD) || event(ZORA_EGGS_TREASURE_ROOM) || event(ZORA_EGGS_PINNACLE_ROCK)"
 "has_chateau": "has_bottle && (renewable(CHATEAU) || renewable(BOTTLE_CHATEAU))"
-"has_big_poe": "event(WELL_BIG_POE)"
+"has_big_poe": "has_bottle && (event(WELL_BIG_POE) || event(DAMPE_BIG_POE))"
 "can_kill_baba_nuts": "soul_deku_baba && (can_fight || has(MASK_DEKU) || can_hookshot_short || has_explosives || has_arrows)"
 "can_kill_baba_sticks": "soul_deku_baba && (can_fight || has(MASK_DEKU) || can_hookshot_short || has_explosives || has_arrows)"
 "can_kill_baba_both_sticks": "soul_deku_baba && (has_weapon || has(MASK_DEKU))"

--- a/packages/core/data/mm/world/beneath_the_well.yml
+++ b/packages/core/data/mm/world/beneath_the_well.yml
@@ -7,19 +7,19 @@
 "Beneath The Well North Section":
   dungeon: BtW
   events:
-    WELL_HOT_WATER: "event(FISH) && (has_explosives || has_mask_zora || trick_keg_explosives || trick(MM_WELL_HSW))"
-    WATER: "true"
-    FISH: "true"
-    BUGS: "event(WATER) && (can_use_fire_arrows || has_sticks)"
-    BOMBS: "event(WATER) && (can_use_fire_arrows || has_sticks)"
-    RUPEES: "event(WATER) && (can_fight || has_weapon_range || has_explosives)"
+    WELL_HOT_WATER: "has_bottle && event(FISH) && (has_explosives || has_mask_zora || trick_keg_explosives || trick(MM_WELL_HSW))"
+    WATER: "has_bottle"
+    FISH: "has_bottle"
+    BUGS: "event(WATER) && has_fire_sticks"
+    BOMBS: "event(WATER) && has_fire_sticks"
+    RUPEES: "event(WATER) && (can_fight || has_weapon_range || has_explosives) && (soul_wallmaster || (event(BUGS) && soul_keese))"
   locations:
     "Beneath The Well Keese Chest": "event(WATER) && event(BUGS) && can_use_lens"
-    "Beneath The Well Pot Left Side 1": "event(WATER) && has_bottle"
-    "Beneath The Well Pot Left Side 2": "event(WATER) && has_bottle"
-    "Beneath The Well Pot Left Side 3": "event(WATER) && has_bottle"
-    "Beneath The Well Pot Left Side 4": "event(WATER) && has_bottle"
-    "Beneath The Well Pot Left Side 5": "event(WATER) && has_bottle"
+    "Beneath The Well Pot Left Side 1": "event(WATER) && has_fire_sticks"
+    "Beneath The Well Pot Left Side 2": "event(WATER) && has_fire_sticks"
+    "Beneath The Well Pot Left Side 3": "event(WATER) && has_fire_sticks"
+    "Beneath The Well Pot Left Side 4": "event(WATER) && has_fire_sticks"
+    "Beneath The Well Pot Left Side 5": "event(WATER) && has_fire_sticks"
 "Beneath The Well East Section":
   dungeon: BtW
   exits:
@@ -29,7 +29,7 @@
   events:
     STICKS: "can_kill_baba_sticks"
     WATER: "has_bottle"
-    RUPEES: "can_fight || has_weapon_range || has_explosives"
+    RUPEES: "(can_fight || has_weapon_range || has_explosives) && soul_keese"
 "Beneath The Well Cow Hall":
   dungeon: BtW
   events:
@@ -45,12 +45,12 @@
   dungeon: BtW
   exits:
     "Beneath The Well East Section": "true"
-    "Beneath The Well Final Hall": "event(WELL_BIG_POE)"
+    "Beneath The Well Final Hall": "has_big_poe"
   events:
     STICKS: "can_kill_baba_both_sticks"
-    NUTS: "true"
+    NUTS: "can_kill_baba_nuts"
   locations:
-    "Beneath The Well Skulltulla Chest": "has(MASK_GIBDO) && soul_redead_gibdo && event(BUGS)"
+    "Beneath The Well Skulltulla Chest": "has(MASK_GIBDO) && soul_redead_gibdo && event(BUGS) && has_fire_sticks"
     "Beneath The Well Pot Middle 01": "true"
     "Beneath The Well Pot Middle 02": "true"
     "Beneath The Well Pot Middle 03": "true"
@@ -67,17 +67,15 @@
     "Beneath The Well Middle Section": "true"
     "Beneath The Well Sun Block": "has(MASK_GIBDO) && soul_redead_gibdo && has_milk"
   events:
-    RUPEES: "can_fight || has_weapon_range || has_explosives"
-    BUGS: "can_use_fire_arrows || (event(WELL_BIG_POE) && has_sticks)"
-  locations:
-    "Beneath The Well Skulltulla Chest": "has(MASK_GIBDO) && soul_redead_gibdo && has_bottle"
+    RUPEES: "(can_fight || has_weapon_range || has_explosives) && soul_wallmaster"
+    BUGS: "can_use_fire_arrows || (has_sticks && has_big_poe && has(MASK_GIBDO) && soul_redead_gibdo)"
 "Beneath The Well Sun Block":
   dungeon: BtW
   exits:
     "Beneath The Well Final Hall": "true"
     "Beneath The Well End": "has_mirror_shield || can_use_light_arrows"
   locations:
-    "Beneath The Well Mirror Shield": "can_use_fire_arrows || event(WELL_BIG_POE)"
+    "Beneath The Well Mirror Shield": "can_use_fire_arrows || (has_sticks && has_big_poe && has_milk && has(MASK_GIBDO) && soul_redead_gibdo)"
 "Beneath The Well End":
   dungeon: BtWE
   exits:

--- a/packages/core/data/mm/world/beneath_the_well.yml
+++ b/packages/core/data/mm/world/beneath_the_well.yml
@@ -7,12 +7,12 @@
 "Beneath The Well North Section":
   dungeon: BtW
   events:
-    WELL_HOT_WATER: "has_bottle && event(FISH) && (has_explosives || has_mask_zora || trick_keg_explosives || trick(MM_WELL_HSW))"
+    WELL_HOT_WATER: "event(FISH) && (has_explosives || has_mask_zora || trick_keg_explosives || trick(MM_WELL_HSW))"
     WATER: "has_bottle"
     FISH: "has_bottle"
     BUGS: "event(WATER) && has_fire_sticks"
     BOMBS: "event(WATER) && has_fire_sticks"
-    RUPEES: "event(WATER) && (can_fight || has_weapon_range || has_explosives) && (soul_wallmaster || (event(BUGS) && soul_keese))"
+    RUPEES: "event(WATER) && (((can_fight || has_weapon_range || has_explosives) && soul_wallmaster) || (event(BUGS) && can_use_light_arrows && soul_keese))"
   locations:
     "Beneath The Well Keese Chest": "event(WATER) && event(BUGS) && can_use_lens"
     "Beneath The Well Pot Left Side 1": "event(WATER) && has_fire_sticks"
@@ -29,7 +29,7 @@
   events:
     STICKS: "can_kill_baba_sticks"
     WATER: "has_bottle"
-    RUPEES: "(can_fight || has_weapon_range || has_explosives) && soul_keese"
+    RUPEES: "((can_fight || has_weapon_range || has_explosives) && soul_wallmaster) || (can_use_light_arrows && soul_keese)"
 "Beneath The Well Cow Hall":
   dungeon: BtW
   events:
@@ -68,7 +68,7 @@
     "Beneath The Well Sun Block": "has(MASK_GIBDO) && soul_redead_gibdo && has_milk"
   events:
     RUPEES: "(can_fight || has_weapon_range || has_explosives) && soul_wallmaster"
-    BUGS: "can_use_fire_arrows || (has_sticks && has_big_poe && has(MASK_GIBDO) && soul_redead_gibdo)"
+    BUGS: "(can_use_fire_arrows || (has_sticks && has_big_poe && has(MASK_GIBDO) && soul_redead_gibdo)) && (can_fight || has_weapon_range || has_explosives || has shield) && has_bottle"
 "Beneath The Well Sun Block":
   dungeon: BtW
   exits:

--- a/packages/core/data/mm/world/beneath_the_well.yml
+++ b/packages/core/data/mm/world/beneath_the_well.yml
@@ -68,7 +68,7 @@
     "Beneath The Well Sun Block": "has(MASK_GIBDO) && soul_redead_gibdo && has_milk"
   events:
     RUPEES: "(can_fight || has_weapon_range || has_explosives) && soul_wallmaster"
-    BUGS: "(can_use_fire_arrows || (has_sticks && has_big_poe && has(MASK_GIBDO) && soul_redead_gibdo)) && (can_fight || has_weapon_range || has_explosives || has shield) && has_bottle"
+    BUGS: "(can_use_fire_arrows || (has_sticks && has_big_poe && has(MASK_GIBDO) && soul_redead_gibdo)) && (can_fight || has_weapon_range || has_explosives || has_shield) && has_bottle"
 "Beneath The Well Sun Block":
   dungeon: BtW
   exits:

--- a/packages/core/data/mm/world/beneath_the_well.yml
+++ b/packages/core/data/mm/world/beneath_the_well.yml
@@ -68,7 +68,7 @@
     "Beneath The Well Sun Block": "has(MASK_GIBDO) && soul_redead_gibdo && has_milk"
   events:
     RUPEES: "(can_fight || has_weapon_range || has_explosives) && soul_wallmaster"
-    BUGS: "(can_use_fire_arrows || (has_sticks && has_big_poe && has(MASK_GIBDO) && soul_redead_gibdo)) && (can_fight || has_weapon_range || has_explosives || has_shield) && has_bottle"
+    BUGS: "(can_use_fire_arrows || (has_sticks && has_big_poe && has(MASK_GIBDO) && soul_redead_gibdo)) && has_bottle"
 "Beneath The Well Sun Block":
   dungeon: BtW
   exits:

--- a/packages/core/data/mm/world/overworld.yml
+++ b/packages/core/data/mm/world/overworld.yml
@@ -1746,7 +1746,8 @@
 "Beneath The Graveyard Night 3":
   region: ENTRANCE
   events:
-    RUPEES: "can_fight || has_weapon_range || has_explosives"
+    RUPEES: "(can_fight || has_weapon_range || has_explosives) && soul_wallmaster"
+    DAMPE_BIG_POE: "has_weapon_range && is_night3"
   exits:
     "Ikana Graveyard": "true"
   locations:


### PR DESCRIPTION
Fixes a few bugs with Beneath the Well's logic, as well as adding support for Dampe's Big Poe.

Summary of changes:

- Added Keese, Deku Baba, and Wallmaster souls for item events where necessary.

- Fixed a logic error for the 5 North Section pots requiring a bottle instead of a fire source.

- Fixed a logic error with the Skulltula chest not requiring a fire source.

- Added a Dampe Big Poe event and adjusted BtW logic to allow either Big Poe to be used.

- Adjusted the logic for the stick torch runs at end of the dungeon to be more robust to accommodate the Big Poe change.

- Adjusted North Section WELL_HOT_WATER, WATER, and FISH events to explicitly require a bottle even though having a bottle is currently implied by having access to the room in the first place. Both future-proofs in the event a crazy new setting revamps how BtW works and is just overall easier to read.



