### PR TITLE
FD "Almost" Anywhere

### DIFF
--- a/packages/core/data/mm/macros.yml
+++ b/packages/core/data/mm/macros.yml
@@ -135,7 +135,7 @@ has(MASK_KAMARO) || has(MASK_GIBDO) || has(MASK_GARO)) || has(MASK_CAPTAIN)" # G
 
 # Misc
 "soul(x)": "(!setting(enemySoulsMm)) || has(x)"
-"fd_anywhere": "has(MASK_FIERCE_DEITY) && (setting(fierceDeityAnywhere) || (glitch(MM_FD_ANYWHERE) && has_regular_mask && is_night3 && !er_enabled && (can_play(SONG_SOARING) || event(SUN_MASK))))"
+"fd_anywhere": "has(MASK_FIERCE_DEITY) && (setting(fierceDeityAnywhere) || (glitch(MM_FD_ANYWHERE) && has_regular_mask && is_night3 && !setting(erRegions, none) && (can_play(SONG_SOARING) || event(SUN_MASK))))"
 "fd_goron_region_access": fd_anywhere && (has(OWL_MOUNTAIN_VILLAGE) || has(OWL_SNOWHEAD))
 "fd_zora_region_access": fd_anywhere && (has(OWL_GREAT_BAY) || has(OWL_ZORA_CAPE))
 "fd_ic_access": "fd_anywhere && (has(OWL_IKANA_CANYON) || has(OWL_STONE_TOWER))"

--- a/packages/core/data/mm/macros.yml
+++ b/packages/core/data/mm/macros.yml
@@ -124,8 +124,15 @@
 "has_mask_keaton": "has(MASK_KEATON) || has(SHARED_MASK_KEATON)"
 "has_mask_zora": "has(MASK_ZORA) || has(SHARED_MASK_ZORA)"
 "has_mask_goron": "has(MASK_GORON) || has(SHARED_MASK_GORON)"
+"has_regular_mask": "has_mask_bunny || has_mask_truth || has(MASK_BLAST || has(MASK_POSTMAN) || has(MASK_BREMEN) ||
+                    has(MASK_KAFEI) || has(MASK_TROUPE_LEADER) || has(MASK_COUPLE) || has_mask_keaton || has(MASK_KAMARO) || has(MASK_SCENTS ||
+                    has(MASK_DON_GERO) || has(MASK_BUNNY) has(MASK_STONE) || has(MASK_GARO)) || has(MASK_GIBDO) || has(MASK_GIANT)"
 
 "er_enabled": "!setting(erDungeons, none) || !setting(erIndoors, none) || !setting(erRegions, none) || !setting(erBoss, none)"
 
 # Misc
 "soul(x)": "(!setting(enemySoulsMm)) || has(x)"
+"fd_anywhere": "has(MASK_FIERCE_DEITY) && (setting(fierceDeityAnywhere) || (glitch(MM_FD_ANYWHERE) && has_regular_mask && is_night3 && !er_enabled && (can_play(SONG_SOARING) || event(SUN_MASK))))"
+"fd_goron_region_access": fd_anywhere && (has(OWL_MOUNTAIN_VILLAGE) || has(OWL_SNOWHEAD))
+"fd_zora_region_access": fd_anywhere && (has(OWL_GREAT_BAY) || has(OWL_ZORA_CAPE))
+"fd_ic_access": "fd_anywhere && (has(OWL_IKANA_CANYON) || has(OWL_STONE_TOWER))"

--- a/packages/core/data/mm/macros.yml
+++ b/packages/core/data/mm/macros.yml
@@ -124,9 +124,12 @@
 "has_mask_keaton": "has(MASK_KEATON) || has(SHARED_MASK_KEATON)"
 "has_mask_zora": "has(MASK_ZORA) || has(SHARED_MASK_ZORA)"
 "has_mask_goron": "has(MASK_GORON) || has(SHARED_MASK_GORON)"
-"has_regular_mask": "has_mask_bunny || has_mask_truth || has(MASK_BLAST || has(MASK_POSTMAN) || has(MASK_BREMEN) ||
-                    has(MASK_KAFEI) || has(MASK_TROUPE_LEADER) || has(MASK_COUPLE) || has_mask_keaton || has(MASK_KAMARO) || has(MASK_SCENTS ||
-                    has(MASK_DON_GERO) || has(MASK_BUNNY) has(MASK_STONE) || has(MASK_GARO)) || has(MASK_GIBDO) || has(MASK_GIANT)"
+
+
+"has_regular_mask": "has(MASK_POSTMAN) || has(MASK_ALL_NIGHT) || has(MASK_BLAST) || has(MASK_STONE) || has(MASK_GREAT_FAIRY) ||
+has_mask_keaton || has(MASK_BREMEN) || has_mask_bunny || has(MASK_DON_GERO) ||
+has(MASK_ROMANI) || has(MASK_TROUPE_LEADER) || has(MASK_KAFEI) || has(MASK_COUPLE) || has_mask_truth ||
+has(MASK_KAMARO) || has(MASK_GIBDO) || has(MASK_GARO)) || has(MASK_CAPTAIN)" # Giant's Mask purposely excluded.
 
 "er_enabled": "!setting(erDungeons, none) || !setting(erIndoors, none) || !setting(erRegions, none) || !setting(erBoss, none)"
 

--- a/packages/core/data/mm/world/overworld.yml
+++ b/packages/core/data/mm/world/overworld.yml
@@ -53,61 +53,61 @@
     "OOT Market": "true"
     "Clock Tower Roof": "after(NIGHT3_AM_12_00)"
   locations:
-    "Clock Town Owl Statue": "has_sticks || has_weapon"
+    "Clock Town Owl Statue": "has_sticks || has_weapon || fd_anywhere"
 "Owl Milk Road":
   region: MILK_ROAD
   exits:
     "Milk Road": "can_reset_time"
   locations:
-    "Milk Road Owl Statue": "has_sticks || has_weapon"
+    "Milk Road Owl Statue": "has_sticks || has_weapon || fd_anywhere"
 "Owl Swamp":
   region: SOUTHERN_SWAMP
   exits:
     "Swamp Front": "can_reset_time"
   locations:
-    "Southern Swamp Owl Statue": "has_sticks || has_weapon"
+    "Southern Swamp Owl Statue": "has_sticks || has_weapon || fd_anywhere"
 "Owl Woodfall":
   region: WOODFALL
   exits:
     "Woodfall Shrine": "can_reset_time"
   locations:
-    "Woodfall Owl Statue": "has_sticks || has_weapon"
+    "Woodfall Owl Statue": "has_sticks || has_weapon || fd_anywhere"
 "Owl Mountain":
   region: MOUNTAIN_VILLAGE
   exits:
     "Mountain Village": "can_reset_time"
   locations:
-    "Mountain Village Owl Statue": "has_sticks || has_weapon"
+    "Mountain Village Owl Statue": "has_sticks || has_weapon || fd_goron_region_access"
 "Owl Snowhead":
   region: SNOWHEAD
   exits:
     "Snowhead Entrance": "can_reset_time"
   locations:
-    "Snowhead Owl Statue": "has_sticks || has_weapon"
+    "Snowhead Owl Statue": "has_sticks || has_weapon || fd_goron_region_access"
 "Owl Great Bay":
   region: GREAT_BAY_COAST
   exits:
     "Great Bay Coast": "can_reset_time"
   locations:
-    "Great Bay Coast Owl Statue": "has_sticks || has_weapon"
+    "Great Bay Coast Owl Statue": "has_sticks || has_weapon || fd_zora_region_access"
 "Owl Zora Cape":
   region: ZORA_CAPE
   exits:
     "Zora Cape Peninsula": "can_reset_time"
   locations:
-    "Zora Cape Owl Statue": "has_sticks || has_weapon"
+    "Zora Cape Owl Statue": "has_sticks || has_weapon || fd_zora_region_access"
 "Owl Ikana":
   region: IKANA_CANYON
   exits:
     "Ikana Canyon": "can_reset_time"
   locations:
-    "Ikana Canyon Owl Statue": "has_sticks || has_weapon"
+    "Ikana Canyon Owl Statue": "has_sticks || has_weapon || fd_anywhere_ic_access"
 "Owl Stone Tower":
   region: STONE_TOWER
   exits:
     "Stone Tower Top": "can_reset_time"
   locations:
-    "Stone Tower Owl Statue": "has_sticks || has_weapon"
+    "Stone Tower Owl Statue": "has_sticks || has_weapon || (fd_anywhere && (has(OWL_STONE_TOWER))"
 "Oath to Order":
   region: GIANT_DREAM
   locations:
@@ -139,8 +139,8 @@
     CLOCK_TOWN_SCRUB: "has(MOON_TEAR)"
     MAIL_LETTER: "has(LETTER_TO_KAFEI) && before(DAY2_AM_11_30)"
   locations:
-    "Clock Town South Chest Lower": "can_hookshot || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB)) || trick(MM_SCT_NOTHING) || can_goron_bomb_jump"
-    "Clock Town South Chest Upper": "(can_hookshot || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB)) || (can_goron_bomb_jump && can_hookshot_short)) && final_day"
+    "Clock Town South Chest Lower": "can_hookshot || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB)) || trick(MM_SCT_NOTHING) || can_goron_bomb_jump || fd_anywhere"
+    "Clock Town South Chest Upper": "(can_hookshot || (has(MASK_DEKU) && event(CLOCK_TOWN_SCRUB)) || (can_goron_bomb_jump && can_hookshot_short) || fd_anywhere) && final_day"
     "Clock Town Platform HP": "true"
     "Clock Town Business Scrub": "event(CLOCK_TOWN_SCRUB)"
     "Clock Town Post Box": "has(MASK_POSTMAN)"
@@ -223,7 +223,7 @@
     "Chest Game": "before(NIGHT1_PM_10_00) || (after(DAY2_AM_06_00) && before(NIGHT2_PM_10_00)) || (after(DAY3_AM_06_00) && before(NIGHT3_PM_10_00))"
     "Honey & Darling Game": "before(NIGHT1_PM_10_00) || (after(DAY2_AM_06_00) && before(NIGHT2_PM_10_00)) || (after(DAY3_AM_06_00) && before(NIGHT3_PM_10_00))"
     "Stock Pot Inn": "has(ROOM_KEY) || between(DAY1_AM_08_00, NIGHT1_PM_08_00) || between(DAY2_AM_08_00, NIGHT2_PM_08_00) || after(DAY3_AM_08_00)"
-    "Stock Pot Inn Roof": "has(MASK_DEKU)"
+    "Stock Pot Inn Roof": "has(MASK_DEKU) || fd_anywhere"
     "Milk Bar": "between(DAY1_AM_10_00, NIGHT1_PM_09_00) || between(DAY2_AM_10_00, NIGHT2_PM_09_00) || between(DAY3_AM_10_00, NIGHT3_PM_09_00) || (has(MASK_ROMANI) && (between(NIGHT1_PM_10_00, NIGHT1_AM_05_00) || between(NIGHT2_PM_10_00, NIGHT2_AM_05_00) || after(NIGHT3_PM_10_00)))"
     "Astral Observatory Passage": "event(BOMBER_CODE) || trick(MM_BOMBER_SKIP)"
   events:
@@ -274,7 +274,7 @@
     "Clock Town North": "true"
   locations:
     "Clock Town Great Fairy": "has(STRAY_FAIRY_TOWN)"
-    "Clock Town Great Fairy Alt": "has(STRAY_FAIRY_TOWN) && (has(MASK_DEKU) || has_mask_goron || has_mask_zora)"
+    "Clock Town Great Fairy Alt": "has(STRAY_FAIRY_TOWN) && (has(MASK_DEKU) || has_mask_goron || has_mask_zora || fd_anywhere)"
 "Clock Tower Roof":
   region: CLOCK_TOWER_ROOF
   events:
@@ -282,8 +282,8 @@
   exits:
     "Moon": "can_play(SONG_ORDER) && special(MOON)"
   locations:
-    "Clock Tower Roof Skull Kid Ocarina": "has_weapon_range && can_play_time"
-    "Clock Tower Roof Skull Kid Song of Time": "has_weapon_range && can_play_time"
+    "Clock Tower Roof Skull Kid Ocarina": "(has_weapon_range || fd_anywhere) && can_play_time"
+    "Clock Tower Roof Skull Kid Song of Time": "(has_weapon_range || fd_anywhere) && can_play_time"
     "Clock Tower Roof Pot 1": "can_play_time"
     "Clock Tower Roof Pot 2": "can_play_time"
     "Clock Tower Roof Pot 3": "can_play_time"
@@ -351,11 +351,11 @@
     "Clock Town West": "true"
   locations:
     "Swordsman School HP": "has(SWORD) && can_use_wallet(1) && before(NIGHT3_PM_11_00)"
-    "Swordsman School Pot 1": "has(SWORD) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 2": "has(SWORD) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 3": "has(SWORD) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 4": "has(SWORD) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 5": "has(SWORD) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 1": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 2": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 3": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 4": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 5": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
 "Lottery":
   region: ENTRANCE
   events:
@@ -513,7 +513,7 @@
     "Termina Field Tall Grass Chest": "true"
     "Termina Field Tree Stump Chest": "can_hookshot_short || can_use_beans"
     "Termina Field Kamaro Mask": "can_play(SONG_HEALING) && midnight"
-    "Termina Field Pot": "can_use_beans || has_bow"
+    "Termina Field Pot": "can_use_beans || has_bow || fd_anywhere"
   gossip:
     "Termina Field Gossip Southeast": "true"
     "Termina Field Gossip Southwest": "true"
@@ -558,7 +558,7 @@
   exits:
     "Termina Field": "true"
   locations:
-    "Termina Field Dodongo Grotto": "soul_dodongo && (has_weapon || has_explosives || has_mask_goron || has_arrows)"
+    "Termina Field Dodongo Grotto": "soul_dodongo && (has_weapon || has_explosives || has_mask_goron || has_arrows || fd_anywhere)"
 "Pillar Grotto":
   region: ENTRANCE
   events:
@@ -690,7 +690,7 @@
     "Road to Southern Swamp Grotto": "true"
     "Tingle Swamp": "has_weapon_range"
   locations:
-    "Road to Southern Swamp HP": "has_weapon_range"
+    "Road to Southern Swamp HP": "has_weapon_range || (fd_anywhere && has_magic)"
   gossip:
     "Road to Southern Swamp Gossip": "true"
 "Swamp Archery":
@@ -720,7 +720,7 @@
   exits:
     "Road to Southern Swamp": "true"
     "Tourist Information": "true"
-    "Swamp Back": "event(BOAT_RIDE) || event(CLEAN_SWAMP) || has_mask_zora || (has(MASK_DEKU) && (has_arrows || can_hookshot_short))"
+    "Swamp Back": "event(BOAT_RIDE) || event(CLEAN_SWAMP) || has_mask_zora || (has(MASK_DEKU) && (has_arrows || can_hookshot_short) || fd_anywhere)"
     "Swamp Potion Shop": "true"
     "Woods of Mystery": "true"
     "Ikana Valley": "false"
@@ -752,23 +752,23 @@
     PICTURE_SWAMP: "has(PICTOGRAPH_BOX)"
     PICTURE_BIG_OCTO: "has(PICTOGRAPH_BOX) && soul_octorok"
   exits:
-    "Swamp Front": "event(BOAT_RIDE) || event(CLEAN_SWAMP) || has_mask_zora || ((has_arrows || can_hookshot) && (has(MASK_DEKU) || has_mask_goron))"
+    "Swamp Front": "event(BOAT_RIDE) || event(CLEAN_SWAMP) || has_mask_zora || ((has_arrows || can_hookshot) && (has(MASK_DEKU) || has_mask_goron)) || fd_anywhere"
     "Deku Palace Front": "true"
-    "Near Swamp Spider House": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP)"
-    "Swamp Canopy Back": "event(CLEAN_SWAMP)"
+    "Near Swamp Spider House": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP) || fd_anywhere"
+    "Swamp Canopy Back": "event(CLEAN_SWAMP) || fd_anywhere"
 "Near Swamp Spider House":
   region: SOUTHERN_SWAMP
   exits:
     "Swamp Spider House": "has_sticks || has_arrows"
-    "Swamp Back": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP)"
-    "Near Swamp Grotto": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP)"
+    "Swamp Back": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP) || fd_anywhere"
+    "Near Swamp Grotto": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP) || fd_anywhere"
 "Near Swamp Grotto":
   region: ENTRANCE
   events:
     MUSHROOM: "has(MASK_SCENTS)"
   exits:
-    "Swamp Front": "(has_arrows || can_hookshot) && has_mask_goron"
-    "Near Swamp Spider House": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP)"
+    "Swamp Front": "(has_arrows || can_hookshot) && has_mask_goron || fd_anywhere"
+    "Near Swamp Spider House": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP) || fd_anywhere"
     "Southern Swamp Grotto": "true"
 "Southern Swamp Grotto":
   region: ENTRANCE
@@ -909,13 +909,13 @@
   exits:
     "Near Swamp Grotto": "true"
     "Deku Palace Cliff": "true"
-    "Swamp Canopy Back": "has(MASK_DEKU)"
+    "Swamp Canopy Back": "has(MASK_DEKU) || fd_anywhere"
 "Swamp Canopy Back":
   region: SOUTHERN_SWAMP
   exits:
-    "Swamp Back": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP)"
+    "Swamp Back": "has(MASK_DEKU) || has_mask_zora || event(CLEAN_SWAMP) || fd_anywhere"
     "Woodfall": "true"
-    "Swamp Canopy Front": "has(MASK_DEKU)"
+    "Swamp Canopy Front": "has(MASK_DEKU) || fd_anywhere"
   locations:
     "Southern Swamp Song of Soaring": "has(MASK_DEKU)"
 "Woodfall":
@@ -924,10 +924,10 @@
     MAGIC: "true"
   exits:
     "Swamp Canopy Back": "true"
-    "Woodfall Shrine": "has(MASK_DEKU) && (soul_deku_scrub || event(CLEAN_SWAMP))"
+    "Woodfall Shrine": "(has(MASK_DEKU) && (soul_deku_scrub || event(CLEAN_SWAMP))) || fd_anywhere"
     "Woodfall Temple Princess Jail": "event(CLEAN_SWAMP) && event(OPEN_WOODFALL_TEMPLE)"
   locations:
-    "Woodfall Entrance Chest": "has(MASK_DEKU) || can_hookshot || event(CLEAN_SWAMP)"
+    "Woodfall Entrance Chest": "has(MASK_DEKU) || can_hookshot || event(CLEAN_SWAMP) || fd_anywhere"
     "Woodfall HP Chest": "(has(MASK_DEKU) && (soul_deku_scrub || event(CLEAN_SWAMP))) || can_hookshot"
     "Woodfall Near Owl Chest": "(has(MASK_DEKU) && (soul_deku_scrub || event(CLEAN_SWAMP))) || (event(CLEAN_SWAMP) && can_hookshot)"
 "Woodfall Front of Temple":
@@ -949,7 +949,7 @@
     NUTS: "true"
     FAIRY: "true"
   locations:
-    "Woodfall Near Owl Chest": "has(MASK_DEKU) || can_hookshot"
+    "Woodfall Near Owl Chest": "has(MASK_DEKU) || can_hookshot || fd_anywhere"
     "Woodfall Pot 1": "true"
     "Woodfall Pot 2": "true"
     "Woodfall Pot 3": "true"
@@ -1207,20 +1207,20 @@
   region: PATH_TO_SNOWHEAD
   exits:
     "Mountain Village": "true"
-    "Path to Snowhead Middle": "goron_fast_roll"
+    "Path to Snowhead Middle": "goron_fast_roll || fd_goron_region_access"
 "Path to Snowhead Middle":
   region: PATH_TO_SNOWHEAD
   exits:
     "Path to Snowhead Front": "true"
     "Path to Snowhead Back": "true"
   locations:
-    "Path to Snowhead HP": "can_use_lens && scarecrow_hookshot"
+    "Path to Snowhead HP": "can_use_lens && (scarecrow_hookshot || fd_goron_region_access)"
 "Path to Snowhead Back":
   region: PATH_TO_SNOWHEAD
   events:
     MAGIC: "can_break_boulders"
   exits:
-    "Path to Snowhead Middle": "goron_fast_roll"
+    "Path to Snowhead Middle": "goron_fast_roll || fd_goron_region_access"
     "Snowhead Entrance": "true"
     "Path to Snowhead Grotto": "has_explosives || trick_keg_explosives"
 "Path to Snowhead Grotto":
@@ -1649,7 +1649,7 @@
   exits:
     "Zora Cape": "has_mask_zora || trick(MM_ZORA_HALL_HUMAN)"
     "Zora Hall": "true"
-    "Great Bay Temple": "has_mask_zora && can_hookshot && can_play(SONG_ZORA)"
+    "Great Bay Temple": "has_mask_zora && can_play(SONG_ZORA) && (can_hookshot || fd_zora_region_access)"
     "Owl Zora Cape": "true"
   locations:
     "Zora Cape Pot Near Owl Statue 1": "true"
@@ -1807,16 +1807,16 @@
     "Road to Ikana Top": "true"
     "Ikana Canyon": "((can_use_ice_arrows && soul_octorok) || trick(MM_ICELESS_IKANA)) && can_hookshot"
     "Secret Shrine": "true"
-    "Sakon Hideout": "event(MEET_KAFEI) && at(NIGHT3_PM_06_00)"
+    "Sakon Hideout": "(event(MEET_KAFEI) && at(NIGHT3_PM_06_00)) || glitch(MM_SAKON_HIDEOUT_CLIP)"
     "Ikana Valley Grotto": "true"
     "Swamp Front": "true"
   locations:
     "Ikana Valley Scrub Rupee": "has(DEED_OCEAN) && has_mask_zora"
-    "Ikana Valley Scrub HP": "has(DEED_OCEAN) && has_mask_zora && has(MASK_DEKU)"
+    "Ikana Valley Scrub HP": "(has(DEED_OCEAN) && has_mask_zora && has(MASK_DEKU)) || fd_anywhere"
     "Ikana Valley Scrub Shop": "can_use_wallet(2)"
   gossip:
     "Ikana Valley Gossip Lower": "true"
-    "Ikana Valley Gossip Scrub": "has(DEED_OCEAN) && has_mask_zora && has(MASK_DEKU)"
+    "Ikana Valley Gossip Scrub": "(has(DEED_OCEAN) && has_mask_zora && has(MASK_DEKU)) || fd_anywhere"
 "Ikana Valley Grotto":
   region: ENTRANCE
   exits:
@@ -1837,13 +1837,13 @@
   exits:
     "Ikana Valley": "true"
   events:
-    SUN_MASK: "(can_fight || has_explosives || has_arrows) && soul_deku_baba && soul_wolfos"
+    SUN_MASK: "(can_fight || has_explosives || has_arrows) && soul_deku_baba && soul_wolfos && is_night3"
   locations:
-    "Sakon Hideout Pot First Room 1": "true"
-    "Sakon Hideout Pot First Room 2": "true"
-    "Sakon Hideout Pot Second Room 1": "soul_deku_baba"
-    "Sakon Hideout Pot Second Room 2": "soul_deku_baba"
-    "Sakon Hideout Pot Third Room": "soul_deku_baba"
+    "Sakon Hideout Pot First Room 1": "is_night3"
+    "Sakon Hideout Pot First Room 2": "is_night3"
+    "Sakon Hideout Pot Second Room 1": "soul_deku_baba && is_night3"
+    "Sakon Hideout Pot Second Room 2": "soul_deku_baba && is_night3"
+    "Sakon Hideout Pot Third Room": "soul_deku_baba && is_night3"
 "Ikana Canyon":
   region: IKANA_CANYON
   exits:
@@ -1892,7 +1892,7 @@
 "Ikana Castle Entrance":
   region: IKANA_CASTLE
   exits:
-    "Ikana Castle Exterior": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT_ENTRANCE)) || can_use_light_arrows"
+    "Ikana Castle Exterior": "(has_mirror_shield && event(IKANA_CASTLE_LIGHT_ENTRANCE)) || can_use_light_arrows || fd_ic_access"
     "Ikana Canyon": "true"
   events:
     IKANA_CASTLE_LIGHT_ENTRANCE: "can_activate_crystal"

--- a/packages/core/data/mm/world/overworld.yml
+++ b/packages/core/data/mm/world/overworld.yml
@@ -351,11 +351,11 @@
     "Clock Town West": "true"
   locations:
     "Swordsman School HP": "has(SWORD) && can_use_wallet(1) && before(NIGHT3_PM_11_00)"
-    "Swordsman School Pot 1": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 2": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 3": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 4": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
-    "Swordsman School Pot 5": "(has(SWORD) || fd_anywhere)) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 1": "has(SWORD) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 2": "has(SWORD) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 3": "has(SWORD) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 4": "has(SWORD) && after(NIGHT3_AM_12_00)"
+    "Swordsman School Pot 5": "has(SWORD) && after(NIGHT3_AM_12_00)"
 "Lottery":
   region: ENTRANCE
   events:

--- a/packages/core/data/mm/world/overworld.yml
+++ b/packages/core/data/mm/world/overworld.yml
@@ -690,7 +690,7 @@
     "Road to Southern Swamp Grotto": "true"
     "Tingle Swamp": "has_weapon_range"
   locations:
-    "Road to Southern Swamp HP": "has_weapon_range || (fd_anywhere && has_magic)"
+    "Road to Southern Swamp HP": "has_weapon_range"
   gossip:
     "Road to Southern Swamp Gossip": "true"
 "Swamp Archery":

--- a/packages/core/data/mm/world/overworld.yml
+++ b/packages/core/data/mm/world/overworld.yml
@@ -282,8 +282,8 @@
   exits:
     "Moon": "can_play(SONG_ORDER) && special(MOON)"
   locations:
-    "Clock Tower Roof Skull Kid Ocarina": "(has_weapon_range || fd_anywhere) && can_play_time"
-    "Clock Tower Roof Skull Kid Song of Time": "(has_weapon_range || fd_anywhere) && can_play_time"
+    "Clock Tower Roof Skull Kid Ocarina": "(has_weapon_range || (fd_anywhere && has_magic)) && can_play_time"
+    "Clock Tower Roof Skull Kid Song of Time": "(has_weapon_range || (fd_anywhere && has_magic)) && can_play_time"
     "Clock Tower Roof Pot 1": "can_play_time"
     "Clock Tower Roof Pot 2": "can_play_time"
     "Clock Tower Roof Pot 3": "can_play_time"

--- a/packages/core/lib/combo/settings/glitches.ts
+++ b/packages/core/lib/combo/settings/glitches.ts
@@ -1,6 +1,8 @@
 export const GLITCHES = {
   OOT_EQUIP_SWAP: "Equip Swap (OoT)",
   OOT_OCARINA_ITEMS: "Ocarina Items (OoT)",
+  MM_SAKON_HIDEOUT_CLIP: "Sakon Hideout Clip",
+  MM_FD_ANYWHERE: "Fierce Diety Anywhere (Night 3)",
 }
 
 export type Glitch = keyof typeof GLITCHES;

--- a/packages/core/lib/combo/settings/glitches.ts
+++ b/packages/core/lib/combo/settings/glitches.ts
@@ -2,7 +2,7 @@ export const GLITCHES = {
   OOT_EQUIP_SWAP: "Equip Swap (OoT)",
   OOT_OCARINA_ITEMS: "Ocarina Items (OoT)",
   MM_SAKON_HIDEOUT_CLIP: "Sakon Hideout Clip",
-  MM_FD_ANYWHERE: "Fierce Diety Anywhere (Night 3)",
+  MM_FD_ANYWHERE: "Fierce Deity Anywhere (Night 3)",
 }
 
 export type Glitch = keyof typeof GLITCHES;

--- a/packages/core/lib/combo/settings/glitches.ts
+++ b/packages/core/lib/combo/settings/glitches.ts
@@ -1,7 +1,7 @@
 export const GLITCHES = {
   OOT_EQUIP_SWAP: "Equip Swap (OoT)",
   OOT_OCARINA_ITEMS: "Ocarina Items (OoT)",
-  MM_SAKON_HIDEOUT_CLIP: "Sakon Hideout Clip",
+  MM_SAKONS_HIDEOUT_CLIP: "Sakon's Hideout Clip",
   MM_FD_ANYWHERE: "Fierce Deity Anywhere (Night 3)",
 }
 


### PR DESCRIPTION
Adds a glitch that allows the player to transform into Fierce Deity via Sakon's Hideout on Night 3.

**Summary of changes**:

- Two new glitches for MM: one for clipping into Sakon's Hideout and another for transforming into FD from within the hideout.
- Logic for FD in the overworld, with some restrictions that are outlined below.

A description of the glitch to transform can be found here:
https://www.youtube.com/watch?v=_iSbNE8y_GU

And a description of the clip here:
https://www.youtube.com/watch?v=PQ9equzULhU

Note that accessing FD via this method is significantly more restrictive than the existing FD Anywhere setting. The mask can not be taken on and off at will - you can not put the mask back on freely once it's taken off and the glitch would need to be triggered again by returning the Hideout on night 3 before acquiring the Sun Mask.

There are a number of ways to remove the FD Mask even without being able to use it on your C-buttons. Any of the following will unequip the mask:
A) Equipping another transformation mask
B) Voiding Out
C) Dying
D) Reloading after a save+quit (including coming from OoT)

For these reasons (particularly the OoT restriction), I disabled this setting from affecting logic if Region ER and the glitch is selected but not the regular setting for the time being. I do not know what a good way to check that a route will exist to a region that will not force unequip the mask.
In addition, only logic for the overworld (minus interiors) was implemented for now.
