### PR TITLE
some hammer logic for enemies

### DIFF
--- a/packages/core/data/oot/world/deku_tree.yml
+++ b/packages/core/data/oot/world/deku_tree.yml
@@ -6,7 +6,7 @@
 "Deku Tree Lobby":
   dungeon: DT
   exits:
-    "Deku Tree Slingshot Room": "soul_deku_scrub && has_shield_for_scrubs"
+    "Deku Tree Slingshot Room": "soul_deku_scrub && (has_shield_for_scrubs || can_hammer)"
     "Deku Tree Basement": "has_fire || has_nuts || has_weapon || has_explosives_or_hammer || has_ranged_weapon || can_use_sticks"
   events:
     STICKS: "can_kill_baba_sticks"

--- a/packages/core/data/oot/world/dodongo_cavern.yml
+++ b/packages/core/data/oot/world/dodongo_cavern.yml
@@ -41,8 +41,8 @@
 "Dodongo Cavern Miniboss 1":
   dungeon: DC
   exits:
-    "Dodongo Cavern Right Corridor": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot)"
-    "Dodongo Cavern Green Room": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot)"
+    "Dodongo Cavern Right Corridor": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot || can_hammer)"
+    "Dodongo Cavern Green Room": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot || can_hammer)"
     "Dodongo Cavern Miniboss 2": "time_travel_at_will && (climb_anywhere || (is_adult && hookshot_anywhere) || longshot_anywhere)"
   locations:
     "Dodongo Cavern Pot Miniboss 1": "true"
@@ -121,8 +121,8 @@
 "Dodongo Cavern Miniboss 2":
   dungeon: DC
   exits:
-    "Dodongo Cavern Bomb Bag Room 1": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot)"
-    "Dodongo Cavern Bomb Bag Room 2": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot)"
+    "Dodongo Cavern Bomb Bag Room 1": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot || can_hammer)"
+    "Dodongo Cavern Bomb Bag Room 2": "soul_lizalfos_dinalfos && (can_use_sticks || has_weapon || can_use_slingshot || can_hammer)"
     "Dodongo Cavern Miniboss 1": "time_travel_at_will"
   locations:
     "Dodongo Cavern Pot Miniboss 1": "true"


### PR DESCRIPTION
lizalfos in DC did not take child hammer into account.
also!
the scrub in deku tree can be hit with hammer. just not other stuff like boomerang etc. 