### PR TITLE
Clock Tower Dungeon ER Option

### DIFF
--- a/packages/core/data/mm/macros.yml
+++ b/packages/core/data/mm/macros.yml
@@ -172,7 +172,7 @@
 "has_mask_zora": "has(MASK_ZORA) || has(SHARED_MASK_ZORA)"
 "has_mask_goron": "has(MASK_GORON) || has(SHARED_MASK_GORON)"
 
-"er_enabled": "setting(erMajorDungeons) || setting(erMinorDungeons) || setting(erSpiderHouses) || setting(erGanonCastle) || setting(erGanonTower) || setting(erBeneathWell) || setting(erPirateFortress) || setting(erSecretShrine) || setting(erIkanaCastle) || setting(erIndoorsMajor) || setting(erIndoorsExtra) || !setting(erRegions, none) || !setting(erBoss, none) || !setting(erWarps, none) || setting(erOneWaysMajor) || setting(erOneWaysIkana) || setting(erOneWaysSongs) || setting(erOneWaysStatues) || setting(erOneWaysOwls)"
+"er_enabled": "setting(erMajorDungeons) || setting(erMinorDungeons) || setting(erSpiderHouses) || setting(erGanonCastle) || setting(erGanonTower) || setting(erBeneathWell) || setting(erPirateFortress) || setting(erSecretShrine) || setting(erIkanaCastle) || setting(erMoon) || setting(erIndoorsMajor) || setting(erIndoorsExtra) || !setting(erRegions, none) || !setting(erBoss, none) || !setting(erWarps, none) || setting(erOneWaysMajor) || setting(erOneWaysIkana) || setting(erOneWaysSongs) || setting(erOneWaysStatues) || setting(erOneWaysOwls)"
 
 # Misc
 "soul_enemy(x)": "(!setting(soulsEnemyMm)) || has(x)"

--- a/packages/core/data/mm/world/ancient_castle_of_ikana.yml
+++ b/packages/core/data/mm/world/ancient_castle_of_ikana.yml
@@ -2,7 +2,7 @@
   dungeon: ACoI
   exits:
     "Ikana Castle Exterior": "true"
-    "Ancient Castle of Ikana Interior": "can_reset_time"
+    "Ancient Castle of Ikana Interior": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
 "Ancient Castle of Ikana Interior":
   dungeon: ACoI
   events:

--- a/packages/core/data/mm/world/ancient_castle_of_ikana.yml
+++ b/packages/core/data/mm/world/ancient_castle_of_ikana.yml
@@ -2,7 +2,7 @@
   dungeon: ACoI
   exits:
     "Ikana Castle Exterior": "true"
-    "Ancient Castle of Ikana Interior": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Ancient Castle of Ikana Interior": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
 "Ancient Castle of Ikana Interior":
   dungeon: ACoI
   events:

--- a/packages/core/data/mm/world/beneath_the_well.yml
+++ b/packages/core/data/mm/world/beneath_the_well.yml
@@ -2,8 +2,8 @@
   dungeon: BtW
   exits:
     "Ikana Canyon": "true"
-    "Beneath The Well North Section": "can_reset_time && can_pass_gibdo && has_blue_potion"
-    "Beneath The Well East Section": "can_reset_time && can_pass_gibdo && has_beans"
+    "Beneath The Well North Section": "can_reset_time && can_pass_gibdo && has_blue_potion && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Beneath The Well East Section": "can_reset_time && can_pass_gibdo && has_beans && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
 "Beneath The Well North Section":
   dungeon: BtW
   events:
@@ -95,5 +95,5 @@
 "Beneath The Well End":
   dungeon: BtWE
   exits:
-    "Beneath The Well Sun Block": "can_reset_time && can_use_light_arrows"
+    "Beneath The Well Sun Block": "can_reset_time && can_use_light_arrows && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
     "Ikana Castle Exterior": "true"

--- a/packages/core/data/mm/world/beneath_the_well.yml
+++ b/packages/core/data/mm/world/beneath_the_well.yml
@@ -2,8 +2,8 @@
   dungeon: BtW
   exits:
     "Ikana Canyon": "true"
-    "Beneath The Well North Section": "can_reset_time && can_pass_gibdo && has_blue_potion && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
-    "Beneath The Well East Section": "can_reset_time && can_pass_gibdo && has_beans && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Beneath The Well North Section": "can_pass_gibdo && has_blue_potion && cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
+    "Beneath The Well East Section": "can_pass_gibdo && has_beans && cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
 "Beneath The Well North Section":
   dungeon: BtW
   events:
@@ -95,5 +95,5 @@
 "Beneath The Well End":
   dungeon: BtWE
   exits:
-    "Beneath The Well Sun Block": "can_reset_time && can_use_light_arrows && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Beneath The Well Sun Block": "can_use_light_arrows && cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
     "Ikana Castle Exterior": "true"

--- a/packages/core/data/mm/world/great_bay_temple.yml
+++ b/packages/core/data/mm/world/great_bay_temple.yml
@@ -1,7 +1,7 @@
 "Great Bay Temple":
   dungeon: GB
   exits:
-    "Great Bay Temple Entrance": "can_reset_time"
+    "Great Bay Temple Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
     "Zora Cape Peninsula": "can_hookshot || short_hook_anywhere"
 "Great Bay Temple Entrance":
   dungeon: GB

--- a/packages/core/data/mm/world/great_bay_temple.yml
+++ b/packages/core/data/mm/world/great_bay_temple.yml
@@ -1,7 +1,7 @@
 "Great Bay Temple":
   dungeon: GB
   exits:
-    "Great Bay Temple Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Great Bay Temple Entrance": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
     "Zora Cape Peninsula": "can_hookshot || short_hook_anywhere"
 "Great Bay Temple Entrance":
   dungeon: GB

--- a/packages/core/data/mm/world/moon.yml
+++ b/packages/core/data/mm/world/moon.yml
@@ -6,12 +6,12 @@
     "Moon": "can_play_order && special(MOON)"
     "OOT Market": "false"
   locations:
-    "Clock Tower Roof Skull Kid Ocarina": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range)"
-    "Clock Tower Roof Skull Kid Song of Time": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range)"
-    "Clock Tower Roof Pot 1": "true"
-    "Clock Tower Roof Pot 2": "true"
-    "Clock Tower Roof Pot 3": "true"
-    "Clock Tower Roof Pot 4": "true"
+    "Clock Tower Roof Skull Kid Ocarina": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || setting(erMoon) || trick(MM_TIMELESS_CLOCK))"
+    "Clock Tower Roof Skull Kid Song of Time": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || setting(erMoon) || trick(MM_TIMELESS_CLOCK))"
+    "Clock Tower Roof Pot 1": "(can_play_time || event(MAJORA) || setting(erMoon) || trick(MM_TIMELESS_CLOCK))"
+    "Clock Tower Roof Pot 2": "(can_play_time || event(MAJORA) || setting(erMoon) || trick(MM_TIMELESS_CLOCK))"
+    "Clock Tower Roof Pot 3": "(can_play_time || event(MAJORA) || setting(erMoon) || trick(MM_TIMELESS_CLOCK))"
+    "Clock Tower Roof Pot 4": "(can_play_time || event(MAJORA) || setting(erMoon) || trick(MM_TIMELESS_CLOCK))"
 "Moon":
   dungeon: MOON
   events:

--- a/packages/core/data/mm/world/ocean_spider_house.yml
+++ b/packages/core/data/mm/world/ocean_spider_house.yml
@@ -1,7 +1,7 @@
 "Ocean Spider House":
   dungeon: OSH
   exits:
-    "Ocean Spider House Front": "can_reset_time && (has_explosives || trick_keg_explosives)"
+    "Ocean Spider House Front": "can_reset_time && (has_explosives || trick_keg_explosives) && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
     "Great Bay Coast": "true"
   locations:
     "Ocean Spider House Wallet": "has(GS_TOKEN_OCEAN, 30)"

--- a/packages/core/data/mm/world/ocean_spider_house.yml
+++ b/packages/core/data/mm/world/ocean_spider_house.yml
@@ -1,7 +1,7 @@
 "Ocean Spider House":
   dungeon: OSH
   exits:
-    "Ocean Spider House Front": "can_reset_time && (has_explosives || trick_keg_explosives) && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Ocean Spider House Front": "(has_explosives || trick_keg_explosives) && cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
     "Great Bay Coast": "true"
   locations:
     "Ocean Spider House Wallet": "has(GS_TOKEN_OCEAN, 30)"

--- a/packages/core/data/mm/world/pirate_fortress.yml
+++ b/packages/core/data/mm/world/pirate_fortress.yml
@@ -2,7 +2,7 @@
   dungeon: PF
   exits:
     "Great Bay Coast Fortress": "has_mask_zora"
-    "Pirate Fortress Entrance": "can_reset_time"
+    "Pirate Fortress Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
 "Pirate Fortress Entrance":
   dungeon: PF
   exits:

--- a/packages/core/data/mm/world/pirate_fortress.yml
+++ b/packages/core/data/mm/world/pirate_fortress.yml
@@ -2,7 +2,7 @@
   dungeon: PF
   exits:
     "Great Bay Coast Fortress": "has_mask_zora"
-    "Pirate Fortress Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Pirate Fortress Entrance": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
 "Pirate Fortress Entrance":
   dungeon: PF
   exits:

--- a/packages/core/data/mm/world/secret_shrine.yml
+++ b/packages/core/data/mm/world/secret_shrine.yml
@@ -2,7 +2,7 @@
   dungeon: SS
   exits:
     "Ikana Valley": "true"
-    "Secret Shrine Entrance": "can_reset_time"
+    "Secret Shrine Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
 "Secret Shrine Entrance":
   dungeon: SS
   events:

--- a/packages/core/data/mm/world/secret_shrine.yml
+++ b/packages/core/data/mm/world/secret_shrine.yml
@@ -2,7 +2,7 @@
   dungeon: SS
   exits:
     "Ikana Valley": "true"
-    "Secret Shrine Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Secret Shrine Entrance": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
 "Secret Shrine Entrance":
   dungeon: SS
   events:

--- a/packages/core/data/mm/world/snowhead_temple.yml
+++ b/packages/core/data/mm/world/snowhead_temple.yml
@@ -1,7 +1,7 @@
 "Snowhead Temple":
   dungeon: SH
   exits:
-    "Snowhead Temple Entrance": "can_reset_time"
+    "Snowhead Temple Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
     "Snowhead": "true"
 "Snowhead Temple Entrance":
   dungeon: SH

--- a/packages/core/data/mm/world/stone_tower_temple.yml
+++ b/packages/core/data/mm/world/stone_tower_temple.yml
@@ -1,7 +1,7 @@
 "Stone Tower Temple":
   dungeon: ST
   exits:
-    "Stone Tower Temple Entrance": "can_reset_time"
+    "Stone Tower Temple Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
     "Stone Tower Front of Temple": "true"
 "Stone Tower Temple Entrance":
   dungeon: ST

--- a/packages/core/data/mm/world/stone_tower_temple.yml
+++ b/packages/core/data/mm/world/stone_tower_temple.yml
@@ -1,7 +1,7 @@
 "Stone Tower Temple":
   dungeon: ST
   exits:
-    "Stone Tower Temple Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Stone Tower Temple Entrance": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
     "Stone Tower Front of Temple": "true"
 "Stone Tower Temple Entrance":
   dungeon: ST

--- a/packages/core/data/mm/world/stone_tower_temple_inverted.yml
+++ b/packages/core/data/mm/world/stone_tower_temple_inverted.yml
@@ -1,7 +1,7 @@
 "Stone Tower Temple Inverted":
   dungeon: IST
   exits:
-    "Stone Tower Temple Inverted Entrance": "can_reset_time"
+    "Stone Tower Temple Inverted Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
     "Stone Tower Top Inverted": "true"
 "Stone Tower Temple Inverted Entrance":
   dungeon: IST

--- a/packages/core/data/mm/world/stone_tower_temple_inverted.yml
+++ b/packages/core/data/mm/world/stone_tower_temple_inverted.yml
@@ -1,7 +1,7 @@
 "Stone Tower Temple Inverted":
   dungeon: IST
   exits:
-    "Stone Tower Temple Inverted Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Stone Tower Temple Inverted Entrance": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
     "Stone Tower Top Inverted": "true"
 "Stone Tower Temple Inverted Entrance":
   dungeon: IST

--- a/packages/core/data/mm/world/swamp_spider_house.yml
+++ b/packages/core/data/mm/world/swamp_spider_house.yml
@@ -2,7 +2,7 @@
   dungeon: SSH
   exits:
     "Near Swamp Spider House": "true"
-    "Swamp Spider House Main": "can_reset_time"
+    "Swamp Spider House Main": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
   locations:
     "Swamp Spider House Mask of Truth": "has(GS_TOKEN_SWAMP, 30)"
 "Swamp Spider House Main":

--- a/packages/core/data/mm/world/swamp_spider_house.yml
+++ b/packages/core/data/mm/world/swamp_spider_house.yml
@@ -2,7 +2,7 @@
   dungeon: SSH
   exits:
     "Near Swamp Spider House": "true"
-    "Swamp Spider House Main": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Swamp Spider House Main": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
   locations:
     "Swamp Spider House Mask of Truth": "has(GS_TOKEN_SWAMP, 30)"
 "Swamp Spider House Main":

--- a/packages/core/data/mm/world/woodfall_temple.yml
+++ b/packages/core/data/mm/world/woodfall_temple.yml
@@ -2,7 +2,7 @@
   dungeon: WF
   exits:
     "Woodfall Front of Temple": "true"
-    "Woodfall Temple Entrance": "can_reset_time"
+    "Woodfall Temple Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
 "Woodfall Temple Entrance":
   dungeon: WF
   events:

--- a/packages/core/data/mm/world/woodfall_temple.yml
+++ b/packages/core/data/mm/world/woodfall_temple.yml
@@ -2,7 +2,7 @@
   dungeon: WF
   exits:
     "Woodfall Front of Temple": "true"
-    "Woodfall Temple Entrance": "can_reset_time && cond(setting(erMoon), before(NIGHT3_AM_12_00), true)"
+    "Woodfall Temple Entrance": "cond(setting(erMoon) && trick(MM_MAJORA_LOGIC), (event(MAJORA) && before(NIGHT3_AM_12_00)) || can_play_time, can_reset_time)"
 "Woodfall Temple Entrance":
   dungeon: WF
   events:

--- a/packages/core/lib/combo/settings/tricks.ts
+++ b/packages/core/lib/combo/settings/tricks.ts
@@ -48,6 +48,8 @@ export const TRICKS = {
   OOT_GTG_CHILD_TT: "Enter Gerudo Training Grounds as Child with Time Travel",
   OOT_REVERSE_DAMPE: "Navigate Dampe's Grave in Reverse",
   OOT_GANON_FAIRY_TT: "Ganon's Great Fairy with Age Swap and without Gold Gauntlets",
+  OOT_GANON_CASTLE_ENTRY: "Enter Ganon's Castle with Longshot Anywhere",
+  OOT_SHADOW_TEMPLE_STICKS: "Enter Shadow Temple with Sticks & Fire Arrows",
   MM_LENS: "Fewer Lens Requirements (MM)",
   MM_PALACE_BEAN_SKIP: "Skip Planting Beans in Deku Palace",
   MM_DARMANI_WALL: "Climb Mountain Village Wall Blind",
@@ -85,8 +87,7 @@ export const TRICKS = {
   MM_GBT_CENTRAL_GEYSER: "GBT Central Room without Zora using Fire & Ice Arrows",
   MM_BANK_ONE_WALLET: "Bank Rewards Require One Less Wallet",
   MM_BANK_NO_WALLET: "Bank Rewards Require No Wallets",
-  OOT_GANON_CASTLE_ENTRY: "Enter Ganon's Castle with Longshot Anywhere",
-  OOT_SHADOW_TEMPLE_STICKS: "Enter Shadow Temple with Sticks & Fire Arrows",
+  MM_TIMELESS_CLOCK: "Clock Tower Items do not Require Time Reset",
 };
 
 export type Trick = keyof typeof TRICKS;


### PR DESCRIPTION
- Adds the option to include the Clock Tower within Dungeon ER
- Enables saving on the Clock Tower to prevent softlocks, only logical for the checks if Moon ER or a new trick for it is on
- Adds mercy timeslots to all MM dungeons to prevent them from appearing in the Clock Tower if you have the Majora Time Reset trick on