### PR TITLE
Weird DC stairs logic

### DIFF
--- a/packages/core/data/oot/world/dodongo_cavern.yml
+++ b/packages/core/data/oot/world/dodongo_cavern.yml
@@ -78,7 +78,7 @@
   exits:
     "Dodongo Cavern Main": "true"
     "Dodongo Cavern Compass Room": "true"
-    "Dodongo Cavern Stairs Top": "has_bombflowers || can_use_din || has_blue_fire_arrows_mudwall || climb_anywhere || hookshot_anywhere"
+    "Dodongo Cavern Stairs Top": "has_bombflowers || can_use_din || climb_anywhere || hookshot_anywhere"
 "Dodongo Cavern Stairs Top":
   dungeon: DC
   exits:


### PR DESCRIPTION
Please double check this, because there may be something that im unaware of... 
but blue fire arrows should not help you get up the stairs in DC. perhaps this logic was innitially intended for the compas room? and if there is some sort of blue fire interaction, arrows should not be here though. 