### PR TITLE
Add option to skip Oath to Order

### DIFF
--- a/packages/core/data/mm/macros.yml
+++ b/packages/core/data/mm/macros.yml
@@ -173,7 +173,7 @@
 "has_mask_goron": "has(MASK_GORON) || has(SHARED_MASK_GORON)"
 
 "er_enabled": "setting(erMajorDungeons) || setting(erMinorDungeons) || setting(erSpiderHouses) || setting(erGanonCastle) || setting(erGanonTower) || setting(erBeneathWell) || setting(erPirateFortress) || setting(erSecretShrine) || setting(erIkanaCastle) || setting(erMoon) || setting(erIndoorsMajor) || setting(erIndoorsExtra) || !setting(erRegions, none) || !setting(erBoss, none) || !setting(erWarps, none) || setting(erOneWaysMajor) || setting(erOneWaysIkana) || setting(erOneWaysSongs) || setting(erOneWaysStatues) || setting(erOneWaysOwls)"
-
+"dungeon_er": "setting(erMajorDungeons) || setting(erSpiderHouses) || setting(erBeneathWell) || setting(erPirateFortress) || setting(erSecretShrine) || setting(erIkanaCastle) || (setting(erDungeons, full) && (setting(erMinorDungeons) || setting(erGanonCastle) || setting(erGanonTower)))"
 # Misc
 "soul_enemy(x)": "(!setting(soulsEnemyMm)) || has(x)"
 "soul_boss(x)": "(!setting(soulsBossMm)) || has(x)"

--- a/packages/core/data/mm/world/moon.yml
+++ b/packages/core/data/mm/world/moon.yml
@@ -7,11 +7,11 @@
     "Clock Tower Platform": "false"
   locations:
     "Clock Tower Roof Skull Kid Ocarina": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || (setting(erMoon) && dungeon_er))"
-    "Clock Tower Roof Skull Kid Song of Time": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || setting(erMoon))"
-    "Clock Tower Roof Pot 1": "(can_play_time || event(MAJORA) || setting(erMoon))"
-    "Clock Tower Roof Pot 2": "(can_play_time || event(MAJORA) || setting(erMoon))"
-    "Clock Tower Roof Pot 3": "(can_play_time || event(MAJORA) || setting(erMoon))"
-    "Clock Tower Roof Pot 4": "(can_play_time || event(MAJORA) || setting(erMoon))"
+    "Clock Tower Roof Skull Kid Song of Time": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || (setting(erMoon) && dungeon_er))"
+    "Clock Tower Roof Pot 1": "(can_play_time || event(MAJORA) || (setting(erMoon) && dungeon_er))"
+    "Clock Tower Roof Pot 2": "(can_play_time || event(MAJORA) || (setting(erMoon) && dungeon_er))"
+    "Clock Tower Roof Pot 3": "(can_play_time || event(MAJORA) || (setting(erMoon) && dungeon_er))"
+    "Clock Tower Roof Pot 4": "(can_play_time || event(MAJORA) || (setting(erMoon) && dungeon_er))"
 "Moon":
   region: MOON
   events:

--- a/packages/core/data/mm/world/moon.yml
+++ b/packages/core/data/mm/world/moon.yml
@@ -3,10 +3,10 @@
   events:
     MAGIC: "true"
   exits:
-    "Moon": "can_play_order && special(MOON)"
+    "Moon": "(can_play_order || setting(openMoon)) && special(MOON)"
     "Clock Tower Platform": "false"
   locations:
-    "Clock Tower Roof Skull Kid Ocarina": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || setting(erMoon))"
+    "Clock Tower Roof Skull Kid Ocarina": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || (setting(erMoon) && dungeon_er))"
     "Clock Tower Roof Skull Kid Song of Time": "cond(!setting(shufflePotsMm), (has(MASK_DEKU) && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))) || has_weapon_range, has_weapon_range) && (can_play_time || event(MAJORA) || setting(erMoon))"
     "Clock Tower Roof Pot 1": "(can_play_time || event(MAJORA) || setting(erMoon))"
     "Clock Tower Roof Pot 2": "(can_play_time || event(MAJORA) || setting(erMoon))"

--- a/packages/core/lib/combo/confvars.ts
+++ b/packages/core/lib/combo/confvars.ts
@@ -101,6 +101,7 @@ export const CONFVARS = [
   'OOT_CHEST_GAME_SHUFFLE',
   'MM_CLIMB_MOST_SURFACES',
   'ER_MOON',
+  'MM_OPEN_MOON',
 ] as const;
 
 export type Confvar = typeof CONFVARS[number];

--- a/packages/core/lib/combo/patch-build/randomizer.ts
+++ b/packages/core/lib/combo/patch-build/randomizer.ts
@@ -725,6 +725,7 @@ function worldConfig(world: World, settings: Settings): Set<Confvar> {
     OOT_TRIAL_SHADOW: world.resolvedFlags.ganonTrials.has('Shadow'),
     OOT_TRIAL_SPIRIT: world.resolvedFlags.ganonTrials.has('Spirit'),
     ER_MOON: settings.erMoon,
+    MM_OPEN_MOON: settings.openMoon,
   };
 
   for (const v in exprs) {

--- a/packages/core/lib/combo/settings/data.ts
+++ b/packages/core/lib/combo/settings/data.ts
@@ -633,6 +633,13 @@ export const SETTINGS = [{
   description: 'This changes the beginning of the child trade quest. True means you\'ll start having already met Zelda and got her item along the one from Impa. And the Chicken is also removed from the game',
   default: false,
 }, {
+  key: 'openMoon',
+  name: 'Skip Oath to Order',
+  category: 'main.events',
+  type: 'boolean',
+  description: 'Skip playing Oath to Order to reach the Moon.',
+  default: false,
+}, {
   key: 'lacs',
   name: 'Light Arrow Cutscene',
   category: 'main.events',

--- a/packages/core/lib/combo/settings/random.ts
+++ b/packages/core/lib/combo/settings/random.ts
@@ -239,6 +239,7 @@ export function applyRandomSettings(rnd: OptionRandomSettings, oldSettings: Sett
   switch (randomInt(random, 4)) {
   case 0:
     base.skipZelda = true;
+    base.openMoon = true;
     base.doorOfTime = 'open';
     base.dekuTree = 'open';
     base.kakarikoGate = 'open';
@@ -247,6 +248,7 @@ export function applyRandomSettings(rnd: OptionRandomSettings, oldSettings: Sett
     break;
   case 1:
     base.skipZelda = false;
+    base.openMoon = false;
     base.doorOfTime = 'closed';
     base.dekuTree = 'closed';
     base.kakarikoGate = 'closed';
@@ -255,6 +257,7 @@ export function applyRandomSettings(rnd: OptionRandomSettings, oldSettings: Sett
     break;
   default:
     base.skipZelda = booleanWeighted(random, 0.3);
+    base.openMoon = booleanWeighted(random, 0.3);
     base.doorOfTime = sampleWeighted(random, { closed: 10, open: 7 });
     base.dekuTree = sampleWeighted(random, { open: 10, closed: 7 });
     base.kakarikoGate = sampleWeighted(random, { closed: 10, open: 7 });

--- a/packages/core/src/common/actors/Custom_Warp.c
+++ b/packages/core/src/common/actors/Custom_Warp.c
@@ -18,6 +18,7 @@ static void CustomWarp_OnTrigger(Actor_CustomWarp* this, GameState_Play* play)
 #define SWITCH_SPRING       0
 #define SWITCH_SWAMP_CLEAR  1
 #define SWITCH_COAST_CLEAR  2
+#define SWITCH_OPEN_MOON    3
 
 static void CustomWarp_OnTrigger(Actor_CustomWarp* this, GameState_Play* play)
 {
@@ -37,6 +38,10 @@ static void CustomWarp_OnTrigger(Actor_CustomWarp* this, GameState_Play* play)
     case SWITCH_COAST_CLEAR:
         MM_SET_EVENT_WEEK(EV_MM_WEEK_DUNGEON_GB);
         play->nextEntrance = ENTR_MM_GREAT_BAY_COAST_FROM_LABORATORY;
+        break;
+    case SWITCH_OPEN_MOON:
+        play->nextEntrance = 0xc800;
+        gSaveContext.timerStates[3] = 0;
         break;
     }
 }
@@ -143,6 +148,14 @@ void comboSpawnCustomWarps(GameState_Play* play)
         x = -3020.f;
         y = 240.f;
         z = 3921.f;
+    }
+
+    if (comboConfig(CFG_MM_OPEN_MOON) && comboSpecialCond(SPECIAL_MOON) && play->sceneId == SCE_MM_CLOCK_TOWER_ROOFTOP)
+    {
+        variable = SWITCH_OPEN_MOON;
+        x = 212.f;
+        y = 30.f;
+        z = 0.f;
     }
 #endif
 

--- a/packages/core/src/mm/actors/Dm/Dm_Stk.c
+++ b/packages/core/src/mm/actors/Dm/Dm_Stk.c
@@ -4,7 +4,7 @@
 
 static void DmStk_Start(Actor* this, GameState_Play* play)
 {
-    if (comboSpecialCond(SPECIAL_MOON))
+    if (comboSpecialCond(SPECIAL_MOON) && !comboConfig(CFG_MM_OPEN_MOON))
     {
         PlayerDisplayTextBox(play, 0x2013, this);
         comboTextHijackOathToOrder(play);


### PR DESCRIPTION
Adds an option under Events to enable skipping Oath to Order to reach the Moon. Complies with the special conditions that are set and, if enabled, removes the Oath hint as it is no longer needed.