### PR TITLE
Fix fishing issues.

### DIFF
--- a/packages/core/include/combo.h
+++ b/packages/core/include/combo.h
@@ -13,7 +13,7 @@
 # define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 // "Length" is how long the fish is, which affects how much it weighs, but I call it weight sometimes anyway.
-# define FISH_WEIGHT_TO_LENGTH(weight) ((s32) (sqrtf((weight - 0.5f) / 0.0036f) + 0.1f)) // Add 0.1 to prevent rounding errors
+# define FISH_WEIGHT_TO_LENGTH(weight) (sqrtf((weight - 0.5f) / 0.0036f) + 1.0f) // Add 1.0 to prevent errors due to truncating
 
 # include <ultra64.h>
 # include <combo/actor_ovl.h>

--- a/packages/core/src/common/item/item_add_oot.c
+++ b/packages/core/src/common/item/item_add_oot.c
@@ -1721,9 +1721,8 @@ int comboAddItemOot(s16 gi, int noEffect)
     {
         u8 caughtListLength = gSharedCustomSave.caughtChildFishWeight[0];
         if (caughtListLength < ARRAY_SIZE(gSharedCustomSave.caughtChildFishWeight) - 1) {
-            f32 lbs = (f32)(gi - GI_OOT_FISHING_POND_CHILD_FISH_2LBS + 2);
-            s32 weight = FISH_WEIGHT_TO_LENGTH(lbs);
-            gSharedCustomSave.caughtChildFishWeight[++gSharedCustomSave.caughtChildFishWeight[0]] = weight & 0x7F;
+            s16 pounds = gi - GI_OOT_FISHING_POND_CHILD_FISH_2LBS + 2;
+            gSharedCustomSave.caughtChildFishWeight[++gSharedCustomSave.caughtChildFishWeight[0]] = pounds & 0x7F;
         }
     }
         break;
@@ -1736,9 +1735,8 @@ int comboAddItemOot(s16 gi, int noEffect)
     {
         u8 caughtListLength = gSharedCustomSave.caughtChildFishWeight[0];
         if (caughtListLength < ARRAY_SIZE(gSharedCustomSave.caughtChildFishWeight) - 1) {
-            f32 lbs = (f32)(gi - GI_OOT_FISHING_POND_CHILD_LOACH_14LBS + 14);
-            s32 weight = FISH_WEIGHT_TO_LENGTH(lbs);
-            gSharedCustomSave.caughtChildFishWeight[++gSharedCustomSave.caughtChildFishWeight[0]] = (weight & 0x7F) | 0x80;
+            s16 pounds = gi - GI_OOT_FISHING_POND_CHILD_LOACH_14LBS + 14;
+            gSharedCustomSave.caughtChildFishWeight[++gSharedCustomSave.caughtChildFishWeight[0]] = (pounds & 0x7F) | 0x80;
         }
     }
         break;
@@ -1767,9 +1765,8 @@ int comboAddItemOot(s16 gi, int noEffect)
     {
         u8 caughtListLength = gSharedCustomSave.caughtAdultFishWeight[0];
         if (caughtListLength < ARRAY_SIZE(gSharedCustomSave.caughtAdultFishWeight) - 1) {
-            f32 lbs = (f32)(gi - GI_OOT_FISHING_POND_ADULT_FISH_4LBS + 4);
-            s32 weight = FISH_WEIGHT_TO_LENGTH(lbs);
-            gSharedCustomSave.caughtAdultFishWeight[++gSharedCustomSave.caughtAdultFishWeight[0]] = weight & 0x7F;
+            s16 pounds = gi - GI_OOT_FISHING_POND_ADULT_FISH_4LBS + 4;
+            gSharedCustomSave.caughtAdultFishWeight[++gSharedCustomSave.caughtAdultFishWeight[0]] = pounds & 0x7F;
         }
     }
         break;
@@ -1784,9 +1781,8 @@ int comboAddItemOot(s16 gi, int noEffect)
     {
         u8 caughtListLength = gSharedCustomSave.caughtAdultFishWeight[0];
         if (caughtListLength < ARRAY_SIZE(gSharedCustomSave.caughtAdultFishWeight) - 1) {
-            f32 lbs = (f32)(gi - GI_OOT_FISHING_POND_ADULT_LOACH_29LBS + 29);
-            s32 weight = FISH_WEIGHT_TO_LENGTH(lbs);
-            gSharedCustomSave.caughtAdultFishWeight[++gSharedCustomSave.caughtAdultFishWeight[0]] = (weight & 0x7F) | 0x80;
+            s16 pounds = gi - GI_OOT_FISHING_POND_ADULT_LOACH_29LBS + 29;
+            gSharedCustomSave.caughtAdultFishWeight[++gSharedCustomSave.caughtAdultFishWeight[0]] = (pounds & 0x7F) | 0x80;
         }
     }
         break;

--- a/packages/core/src/oot/actors/Misc/Fishing.S
+++ b/packages/core/src/oot/actors/Misc/Fishing.S
@@ -299,8 +299,8 @@ Replaces:
 PATCH_START 0x80a3579c
   jal       Fishing_IsFishLoach
   or        a0, v0, zero
-  bnez      v0, .+0x54
   nop
+  bnez      v0, .+0x50
 PATCH_END
 
 /*
@@ -383,6 +383,30 @@ PATCH_START 0x80a3f4e8
   nop
   b         .+0x38
   nop
+PATCH_END
+
+/*
+Replaces:
+  LBU       T8, 0x0140 (S0)
+*/
+PATCH_START 0x80a3c0b4
+  lbu       t8, 0x0143 (s0)
+PATCH_END
+
+/*
+Replaces:
+  LBU       T1, 0x0140 (S0)
+*/
+PATCH_START 0x80a3f598
+  lbu       t1, 0x0143 (s0)
+PATCH_END
+
+/*
+Replaces:
+  LBU       T6, 0x0140 (S0)
+*/
+PATCH_START 0x80a40530
+  lbu       t6, 0x0143 (s0)
 PATCH_END
 
 PATCH_GROUP_END

--- a/packages/core/src/oot/actors/Misc/Fishing.c
+++ b/packages/core/src/oot/actors/Misc/Fishing.c
@@ -206,7 +206,7 @@ s32 Fishing_IsFishLoach(u16 variable) {
         return 1;
     }
 
-    return variable < 115;
+    return variable >= 115;
 }
 
 void Fishing_OverrideInitFishLength(u8 linkAge, f32 childMultiplier, Actor* this) {

--- a/packages/core/src/oot/actors/Misc/Fishing.c
+++ b/packages/core/src/oot/actors/Misc/Fishing.c
@@ -109,33 +109,33 @@ PATCH_CALL(0x80a405d8, Fishing_DrawFish_SkelAnime);
 PATCH_CALL(0x80a4066c, Fishing_DrawFish_SkelAnime);
 
 static f32 Fishing_GetFishOnHand(u8* sFishOnHandIsLoach, s32 take) {
-    u8 weight = 0;
+    u8 pounds = 0;
     if (gSave.age == AGE_ADULT) {
         if (gSharedCustomSave.caughtAdultFishWeight[0]) {
-            weight = gSharedCustomSave.caughtAdultFishWeight[gSharedCustomSave.caughtAdultFishWeight[0]];
+            pounds = gSharedCustomSave.caughtAdultFishWeight[gSharedCustomSave.caughtAdultFishWeight[0]];
             if (take) {
                 gSharedCustomSave.caughtAdultFishWeight[0]--;
             }
         }
     } else {
         if (gSharedCustomSave.caughtChildFishWeight[0]) {
-            weight = gSharedCustomSave.caughtChildFishWeight[gSharedCustomSave.caughtChildFishWeight[0]];
+            pounds = gSharedCustomSave.caughtChildFishWeight[gSharedCustomSave.caughtChildFishWeight[0]];
             if (take) {
                 gSharedCustomSave.caughtChildFishWeight[0]--;
             }
         }
     }
 
-    if (weight) {
-        if (weight & 0x80) {
+    if (pounds) {
+        if (pounds & 0x80) {
             // Loach
             *sFishOnHandIsLoach = 1;
         } else {
             // Fish
             *sFishOnHandIsLoach = 0;
         }
-        weight &= 0x7F;
-        return (f32) weight;
+        pounds &= 0x7F;
+        return FISH_WEIGHT_TO_LENGTH(pounds);
     }
     return 0;
 }

--- a/packages/core/src/oot/actors/Misc/Fishing.c
+++ b/packages/core/src/oot/actors/Misc/Fishing.c
@@ -211,6 +211,7 @@ s32 Fishing_IsFishLoach(u16 variable) {
 
 void Fishing_OverrideInitFishLength(u8 linkAge, f32 childMultiplier, Actor* this) {
     f32* fishLength = (f32*)(((u8*)this)+0x19C);
+    u8* appearsAsLoach = (((u8*)this)+0x143); // unused padding in Fishing struct
 
     // Displaced code:
     if (linkAge == AGE_CHILD) {
@@ -234,10 +235,12 @@ void Fishing_OverrideInitFishLength(u8 linkAge, f32 childMultiplier, Actor* this
     else if (o.gi >= GI_OOT_FISHING_POND_CHILD_LOACH_14LBS && o.gi <= GI_OOT_FISHING_POND_CHILD_LOACH_19LBS)
     {
         pounds = o.gi - GI_OOT_FISHING_POND_CHILD_LOACH_14LBS + 14;
+        *appearsAsLoach = 1;
     }
     else if (o.gi >= GI_OOT_FISHING_POND_ADULT_LOACH_29LBS && o.gi <= GI_OOT_FISHING_POND_ADULT_LOACH_36LBS)
     {
         pounds = o.gi - GI_OOT_FISHING_POND_ADULT_LOACH_29LBS + 29;
+        *appearsAsLoach = 1;
     }
     else
     {
@@ -247,6 +250,9 @@ void Fishing_OverrideInitFishLength(u8 linkAge, f32 childMultiplier, Actor* this
     if (pounds)
     {
         *fishLength = FISH_WEIGHT_TO_LENGTH(pounds);
+        if (*appearsAsLoach) {
+            *fishLength *= 0.5f;
+        }
     }
 }
 


### PR DESCRIPTION
* Fix issues when a fish appears as a loach: limb rotations of the loach were messed up; model reverted to a fish when being released after being caught; model was way too big.
* Fix inconsequential incorrect result of Fishing_IsFishLoach. This only affects which fish skeleton is loaded when the item is neither a fish nor a loach, but the skeleton isn't drawn anyway in that case.
* Fix inconsistencies between fish weight as placed by the randomizer, and the weight given by the fishing pond owner. Fish found are now stored as pounds instead of length, then only converted when needed to be weighed.