### PR TITLE
fix MQ Fire Hammer chest being in logic for child

### DIFF
--- a/packages/data/src/world/mq/fire_temple_mq.yml
+++ b/packages/data/src/world/mq/fire_temple_mq.yml
@@ -25,7 +25,7 @@
 "Fire Temple Vanilla Hammer Loop":
   dungeon: Fire
   locations:
-    "MQ Fire Temple Hammer Chest": "has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS) && soul_iron_knuckle && soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (has_bombs || can_hammer || can_hookshot)"
+    "MQ Fire Temple Hammer Chest": "(is_adult || can_hookshot || climb_anywhere) && has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS) && soul_iron_knuckle && soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (has_bombs || can_hammer || can_hookshot)"
     "MQ Fire Temple Map Chest": "can_hammer && has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS) && soul_iron_knuckle && soul_enemy(SOUL_ENEMY_FLARE_DANCER)"
     "MQ Fire Temple Pot Hammer Loop 1": "has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS)"
     "MQ Fire Temple Pot Hammer Loop 2": "has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS)"


### PR DESCRIPTION
The chest spawns on a ledge that is too high too jump up to as child. 

(I considered the possibility of spawning the chest as child then collecting as adult, but I don't think child has any options to kill the flare dancer that adult does not have access to. If there is another way, it's not already in logic so that could be added by someone later)