### PR TITLE
Improve error messages for incompatible ROMs 

### DIFF
--- a/packages/core/lib/combo/decompress.ts
+++ b/packages/core/lib/combo/decompress.ts
@@ -58,7 +58,13 @@ const checkGameHash = (game: Game, rom: Buffer) => {
   const h = CRC32.buf(rom, 0) >>> 0;
   const hashes = CONFIG[game].crc32;
   if (!hashes.includes(h)) {
-    throw new Error(`Bad hash for ${game}, got ${h.toString(16)}`);
+    let romInfo = '';
+    if (game == 'oot') {
+      romInfo = '. For OOT, use a ROM with version 1.0, U or J.';
+    } else if (game == 'mm') {
+      romInfo = '. For MM, use a ROM with version U.';
+    } 
+    throw new Error(`Incompatable ROM file for ${game} (hash: ${h.toString(16)})${romInfo}`);
   }
 };
 

--- a/packages/data/src/world/mq/fire_temple_mq.yml
+++ b/packages/data/src/world/mq/fire_temple_mq.yml
@@ -25,7 +25,7 @@
 "Fire Temple Vanilla Hammer Loop":
   dungeon: Fire
   locations:
-    "MQ Fire Temple Hammer Chest": "has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS) && soul_iron_knuckle && soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (has_bombs || can_hammer || can_hookshot)"
+    "MQ Fire Temple Hammer Chest": "(is_adult || can_hookshot || climb_anywhere) && has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS) && soul_iron_knuckle && soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (has_bombs || can_hammer || can_hookshot)"
     "MQ Fire Temple Map Chest": "can_hammer && has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS) && soul_iron_knuckle && soul_enemy(SOUL_ENEMY_FLARE_DANCER)"
     "MQ Fire Temple Pot Hammer Loop 1": "has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS)"
     "MQ Fire Temple Pot Hammer Loop 2": "has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS)"


### PR DESCRIPTION
The text of the Error thrown when an incompatible ROM is selected is shown to users on the ootmm website. Many people don't understand what 'bad file hash' means and end up needing to ask about it on the ootmm discord.

This commit addresses this by suggesting the user use a ROM that is compatible.

This code is untested. I don't even know if it compiles.