### PR TITLE
Improve error messages for incompatible ROMs

### DIFF
--- a/packages/core/lib/combo/decompress.ts
+++ b/packages/core/lib/combo/decompress.ts
@@ -57,7 +57,13 @@ const checkGameHash = (game: Game, rom: Buffer) => {
   const h = CRC32.buf(rom, 0) >>> 0;
   const hashes = CONFIG[game].crc32;
   if (!hashes.includes(h)) {
-    throw new Error(`Bad hash for ${game}, got ${h.toString(16)}`);
+    let romInfo = '';
+    if (game == 'oot') {
+      romInfo = '. For OOT, use a ROM with version 1.0, U or J.';
+    } else if (game == 'mm') {
+      romInfo = '. For MM, use a ROM with version U.';
+    } 
+    throw new Error(`Incompatable ROM file for ${game} (hash: ${h.toString(16)})${romInfo}`);
   }
 };
 


### PR DESCRIPTION
The text of the Error thrown when an incompatible ROM is selected is shown to users on the ootmm website. Many people don't understand what 'bad file hash' means and end up needing to ask about it on the ootmm discord.

This commit addresses this by suggesting the user use a ROM that is compatible.

This code is untested. I don't even know if it compiles.