### PR TITLE
Allow age change only after Ocarina Free Play. 

### DIFF
--- a/packages/core/include/combo/oot/play.h
+++ b/packages/core/include/combo/oot/play.h
@@ -36,7 +36,8 @@ typedef struct PACKED
     char unk_e3e6[0x06];
     u16  lastSongPlayed;
     u16  ocarinaMode;
-    char unk_e3f0[0x28];
+    u16  ocarinaAction;
+    char unk_e3f2[0x26];
 }
 MessageContext;
 

--- a/packages/core/src/oot/ocarina.c
+++ b/packages/core/src/oot/ocarina.c
@@ -67,6 +67,13 @@ void Ocarina_HandleLastPlayedSong(GameState_Play* play, Actor_Player* player, s1
         canChangeAge = comboConfig(CFG_OOT_AGE_CHANGE) && GetEventChk(EV_OOT_CHK_MASTER_SWORD_CHAMBER) && GetEventChk(EV_OOT_CHK_MASTER_SWORD_PULLED);
         if (canChangeAge && comboConfig(CFG_OOT_AGE_CHANGE_NEEDS_OOT) && gSave.inventory.items[ITS_OOT_OCARINA] != ITEM_OOT_OCARINA_TIME)
             canChangeAge = 0;
+#if defined(DEBUG)
+        canChangeAge = 1;
+#endif
+        if (play->msgCtx.ocarinaAction != 0x29) // OCARINA_ACTION_FREE_PLAY_DONE
+        {
+            canChangeAge = 0;
+        }
         if (canChangeAge)
         {
             switch (play->sceneId)


### PR DESCRIPTION
Revert if this is too restrictive and try another way.