### PR TITLE
Fix logic requiring Saria's Soul to leave Kokiri forest

### DIFF
--- a/packages/data/src/world/oot/overworld.yml
+++ b/packages/data/src/world/oot/overworld.yml
@@ -859,14 +859,12 @@
     "Kokiri Forest": "true"
     "Hyrule Field": "true"
     "Lost Woods": "can_longshot || hookshot_anywhere"
-  locations:
-    "Lost Woods Gift from Saria": "event(SARIA_GIFT)"
 "Lost Woods Bridge from Forest":
   region: LOST_WOODS
   exits:
-    "Lost Woods Bridge": "event(SARIA_GIFT)"
-  events:
-    SARIA_GIFT: "soul_npc(SOUL_NPC_SARIA)"
+    "Lost Woods Bridge": "true"
+  locations:
+    "Lost Woods Gift from Saria": "soul_npc(SOUL_NPC_SARIA)"
 "Lost Woods Deep":
   region: LOST_WOODS
   exits:


### PR DESCRIPTION
Previously, logic expected you to have Saria's soul to be able to get through the lost woods bridge from the kokiri side to the hyrule side.

Leaving the 'bridge from forest' region, which allows you to get Saria's Gift, is now just 'true' since regardless of whether you get the check or not, you still have access to go from forest entrance to field entrance.

I also removed the Saria Gift event and moved its logic (checking for soul) to the Saria Gift location, which is now moved to the 'bridge from forest' region. The event seemed superfluous.