### PR TITLE
Fix Ice Cavern Big Fairy

### DIFF
--- a/packages/data/src/pool/pool_oot.csv
+++ b/packages/data/src/pool/pool_oot.csv
@@ -1085,7 +1085,7 @@ Ice Cavern Rupee Midair 3,                                  rupee,          NONE
 Ice Cavern Heart 1,                                         heart,          NONE,                 ICE_CAVERN,                     0x00906,                    RECOVERY_HEART
 Ice Cavern Heart 2,                                         heart,          NONE,                 ICE_CAVERN,                     0x00907,                    RECOVERY_HEART
 Ice Cavern Heart 3,                                         heart,          NONE,                 ICE_CAVERN,                     0x00908,                    RECOVERY_HEART
-Ice Cavern Scythe Big Fairy,                                fairy_spot,     NONE,                 ICE_CAVERN,                     0x0010d,                    FAIRY_BIG
+Ice Cavern Entrance Big Fairy,                              fairy_spot,     NONE,                 ICE_CAVERN,                     0x0010d,                    FAIRY_BIG
 Water Temple Under Center,                                  chest,          NONE,                 TEMPLE_WATER,                   0x06,                       RUPEE_BLUE
 Water Temple Compass,                                       chest,          NONE,                 TEMPLE_WATER,                   0x09,                       COMPASS_WATER
 Water Temple Longshot,                                      chest,          NONE,                 TEMPLE_WATER,                   0x07,                       HOOKSHOT

--- a/packages/data/src/world/oot/ice_cavern.yml
+++ b/packages/data/src/world/oot/ice_cavern.yml
@@ -6,6 +6,7 @@
     "Ice Cavern End": "has_iron_boots && (climb_anywhere || hookshot_anywhere)"
   locations:
     "Ice Cavern Rupee Ice": "has_blue_fire"
+    "Ice Cavern Entrance Big Fairy": "can_play_storms"
 "Ice Cavern Scythe":
   dungeon: IC
   exits:
@@ -25,7 +26,6 @@
     "Ice Cavern Pot Scythe Room 2": "true"
     "Ice Cavern Pot Scythe Room 3": "true"
     "Ice Cavern Flying Pot Scythe Room": "soul_flying_pot"
-    "Ice Cavern Scythe Big Fairy": "can_play_storms"
 "Ice Cavern HP Room":
   dungeon: IC
   events:


### PR DESCRIPTION
Rename Ice Cavern Scythe Big Fairy to Ice Cavern Entrance Big Fairy and fix logic.