### PR TITLE
Add setting for opening the MM dungeons during clear state

### DIFF
--- a/packages/core/lib/combo/confvars.ts
+++ b/packages/core/lib/combo/confvars.ts
@@ -119,6 +119,8 @@ export const CONFVARS = [
   'MM_OPEN_SH',
   'MM_OPEN_GB',
   'MM_OPEN_ST',
+  'MM_CLEAR_OPEN_WF',
+  'MM_CLEAR_OPEN_GB',
   'MM_SPELL_FIRE',
   'MM_SPELL_WIND',
   'MM_SPELL_LOVE',

--- a/packages/core/lib/combo/patch-build/randomizer.ts
+++ b/packages/core/lib/combo/patch-build/randomizer.ts
@@ -778,6 +778,8 @@ function worldConfig(world: World, settings: Settings): Set<Confvar> {
     MM_OPEN_SH: world.resolvedFlags.openDungeonsMm.has('SH'),
     MM_OPEN_GB: world.resolvedFlags.openDungeonsMm.has('GB'),
     MM_OPEN_ST: world.resolvedFlags.openDungeonsMm.has('ST'),
+    MM_CLEAR_OPEN_WF: settings.clearStateDungeonsMm === 'WF' || settings.clearStateDungeonsMm === 'both',
+    MM_CLEAR_OPEN_GB: settings.clearStateDungeonsMm === 'GB' || settings.clearStateDungeonsMm === 'both',
     MM_SPELL_FIRE: settings.spellFireMm,
     MM_SPELL_WIND: settings.spellWindMm,
     MM_SPELL_LOVE: settings.spellLoveMm,

--- a/packages/core/lib/combo/settings/data.ts
+++ b/packages/core/lib/combo/settings/data.ts
@@ -693,6 +693,19 @@ export const SETTINGS = [{
   ],
   default: 'none'
 }, {
+  key: 'clearStateDungeonsMm',
+  name: 'Clear State Dungeons (MM)',
+  category: 'main.events',
+  type: 'enum',
+  description: 'Make some MM dungeons open during clear state..',
+  values: [
+    { value: 'none', name: 'None' },
+    { value: 'WF', name: 'Woodfall Temple' },
+    { value: 'GB', name: 'Great Bay Temple' },
+    { value: 'both', name: 'Both' },
+  ],
+  default: 'none'
+}, {
   key: 'kakarikoGate',
   name: 'Kakariko Gate',
   category: 'main.events',

--- a/packages/core/lib/combo/settings/random.ts
+++ b/packages/core/lib/combo/settings/random.ts
@@ -245,6 +245,7 @@ export function applyRandomSettings(rnd: OptionRandomSettings, oldSettings: Sett
     base.skipZelda = true;
     base.openMoon = true;
     base.openDungeonsMm = { type: 'all' };
+    base.clearStateDungeonsMm = 'both';
     base.doorOfTime = 'open';
     base.dekuTree = 'open';
     base.kakarikoGate = 'open';
@@ -255,6 +256,7 @@ export function applyRandomSettings(rnd: OptionRandomSettings, oldSettings: Sett
     base.skipZelda = false;
     base.openMoon = false;
     base.openDungeonsMm = { type: 'none' };
+    base.clearStateDungeonsMm = 'none';
     base.doorOfTime = 'closed';
     base.dekuTree = 'closed';
     base.kakarikoGate = 'closed';
@@ -265,6 +267,7 @@ export function applyRandomSettings(rnd: OptionRandomSettings, oldSettings: Sett
     base.skipZelda = booleanWeighted(random, 0.3);
     base.openMoon = booleanWeighted(random, 0.3);
     base.openDungeonsMm = { type: 'random' };
+    base.clearStateDungeonsMm = sampleWeighted(random, { none: 5, WF: 1, GB: 1, both: 2 });
     base.doorOfTime = sampleWeighted(random, { closed: 10, open: 7 });
     base.dekuTree = sampleWeighted(random, { open: 10, closed: 7 });
     base.kakarikoGate = sampleWeighted(random, { closed: 10, open: 7 });

--- a/packages/core/src/common/actors/Custom_Warp.c
+++ b/packages/core/src/common/actors/Custom_Warp.c
@@ -36,10 +36,18 @@ static void CustomWarp_OnTrigger(Actor_CustomWarp* this, GameState_Play* play)
         break;
     case SWITCH_SWAMP_CLEAR:
         MM_SET_EVENT_WEEK(EV_MM_WEEK_DUNGEON_WF);
+        if (comboConfig(CFG_MM_CLEAR_OPEN_WF))
+        {
+            MM_SET_EVENT_WEEK(EV_MM_WEEK_WOODFALL_TEMPLE_RISE);
+        }
         play->nextEntrance = 0x0ca0;
         break;
     case SWITCH_COAST_CLEAR:
         MM_SET_EVENT_WEEK(EV_MM_WEEK_DUNGEON_GB);
+        if (comboConfig(CFG_MM_CLEAR_OPEN_GB))
+        {
+            MM_SET_EVENT_WEEK(EV_MM_WEEK_GREAT_BAY_TURTLE);
+        }
         play->nextEntrance = ENTR_MM_GREAT_BAY_COAST_FROM_LABORATORY;
         break;
     case SWITCH_OPEN_MOON:

--- a/packages/core/src/common/dungeon.c
+++ b/packages/core/src/common/dungeon.c
@@ -19,6 +19,10 @@ void comboDungeonSetFlags(int dungeonId, int mmCycle)
         if (mmCycle)
         {
             MM_SET_EVENT_WEEK(EV_MM_WEEK_DUNGEON_WF);
+            if (comboConfig(CFG_MM_CLEAR_OPEN_WF))
+            {
+                MM_SET_EVENT_WEEK(EV_MM_WEEK_WOODFALL_TEMPLE_RISE);
+            }
         }
         gMiscFlags.erSwampClear = 1;
         break;
@@ -35,6 +39,10 @@ void comboDungeonSetFlags(int dungeonId, int mmCycle)
         if (mmCycle)
         {
             MM_SET_EVENT_WEEK(EV_MM_WEEK_DUNGEON_GB);
+            if (comboConfig(CFG_MM_CLEAR_OPEN_GB))
+            {
+                MM_SET_EVENT_WEEK(EV_MM_WEEK_GREAT_BAY_TURTLE);
+            }
         }
         gMiscFlags.erCoastClear = 1;
         break;

--- a/packages/data/src/macros/macros_mm.yml
+++ b/packages/data/src/macros/macros_mm.yml
@@ -134,9 +134,9 @@
 "can_pass_gibdo": "has(MASK_GIBDO) && soul_redead_gibdo"
 "can_get_gossip_fairy": "can_play_healing || can_play_epona"
 "can_jumpslash": "has_weapon || has_sticks || has_mask_zora"
-"woodfall_raised": "event(OPEN_WOODFALL_TEMPLE) || setting(openDungeonsMm, WF) || (setting(clearStateDungeonsMm, WF) && event(CLEAN_SWAMP))"
+"woodfall_raised": "event(OPEN_WOODFALL_TEMPLE) || setting(openDungeonsMm, WF) || ((setting(clearStateDungeonsMm, WF) || setting(clearStateDungeonsMm, both)) && event(CLEAN_SWAMP))"
 "blizzard_stopped": "event(OPEN_SNOWHEAD_TEMPLE) || setting(openDungeonsMm, SH) || event(BOSS_SNOWHEAD)"
-"turtle_woken": "(can_play_zora && has_mask_zora) || setting(openDungeonsMm, GB) || (setting(clearStateDungeonsMm, GB) && event(BOSS_GREAT_BAY))"
+"turtle_woken": "(can_play_zora && has_mask_zora) || setting(openDungeonsMm, GB) || ((setting(clearStateDungeonsMm, GB) || setting(clearStateDungeonsMm, both)) && event(BOSS_GREAT_BAY))"
 
 # Bottles
 "has_bottle": "has(BOTTLE_EMPTY) || has(BOTTLE_POTION_RED) || has(BOTTLE_POTION_GREEN) || has(BOTTLE_POTION_BLUE) || has(BOTTLE_MILK) || event(GOLD_DUST_USED) || has(BOTTLE_CHATEAU) || has(BOTTLE_FAIRY) || has(BOTTLE_POE) || has(BOTTLE_BIG_POE)"

--- a/packages/data/src/macros/macros_mm.yml
+++ b/packages/data/src/macros/macros_mm.yml
@@ -136,7 +136,7 @@
 "can_jumpslash": "has_weapon || has_sticks || has_mask_zora"
 "woodfall_raised": "event(OPEN_WOODFALL_TEMPLE) || setting(openDungeonsMm, WF) || (setting(clearStateDungeonsMm, WF) && event(CLEAN_SWAMP))"
 "blizzard_stopped": "event(OPEN_SNOWHEAD_TEMPLE) || setting(openDungeonsMm, SH) || event(BOSS_SNOWHEAD)"
-"turtle_woken": "(can_play_zora && has(MASK_ZORA)) || setting(openDungeonsMm, GB) || (setting(clearStateDungeonsMm, GB) && event(BOSS_GREAT_BAY))"
+"turtle_woken": "(can_play_zora && has_mask_zora) || setting(openDungeonsMm, GB) || (setting(clearStateDungeonsMm, GB) && event(BOSS_GREAT_BAY))"
 
 # Bottles
 "has_bottle": "has(BOTTLE_EMPTY) || has(BOTTLE_POTION_RED) || has(BOTTLE_POTION_GREEN) || has(BOTTLE_POTION_BLUE) || has(BOTTLE_MILK) || event(GOLD_DUST_USED) || has(BOTTLE_CHATEAU) || has(BOTTLE_FAIRY) || has(BOTTLE_POE) || has(BOTTLE_BIG_POE)"

--- a/packages/data/src/macros/macros_mm.yml
+++ b/packages/data/src/macros/macros_mm.yml
@@ -134,6 +134,9 @@
 "can_pass_gibdo": "has(MASK_GIBDO) && soul_redead_gibdo"
 "can_get_gossip_fairy": "can_play_healing || can_play_epona"
 "can_jumpslash": "has_weapon || has_sticks || has_mask_zora"
+"woodfall_raised": "event(OPEN_WOODFALL_TEMPLE) || setting(openDungeonsMm, WF) || (setting(clearStateDungeonsMm, WF) && event(CLEAN_SWAMP))"
+"blizzard_stopped": "event(OPEN_SNOWHEAD_TEMPLE) || setting(openDungeonsMm, SH) || event(BOSS_SNOWHEAD)"
+"turtle_woken": "(can_play_zora && has(MASK_ZORA)) || setting(openDungeonsMm, GB) || (setting(clearStateDungeonsMm, GB) && event(BOSS_GREAT_BAY))"
 
 # Bottles
 "has_bottle": "has(BOTTLE_EMPTY) || has(BOTTLE_POTION_RED) || has(BOTTLE_POTION_GREEN) || has(BOTTLE_POTION_BLUE) || has(BOTTLE_MILK) || event(GOLD_DUST_USED) || has(BOTTLE_CHATEAU) || has(BOTTLE_FAIRY) || has(BOTTLE_POE) || has(BOTTLE_BIG_POE)"

--- a/packages/data/src/world/mm/overworld.yml
+++ b/packages/data/src/world/mm/overworld.yml
@@ -1516,7 +1516,7 @@
   exits:
     "Swamp Canopy Back": "true"
     "Woodfall Shrine": "(has(MASK_DEKU) && (soul_deku_scrub || event(CLEAN_SWAMP))) || hookshot_anywhere"
-    "Woodfall Temple Princess Jail": "event(CLEAN_SWAMP) && (event(OPEN_WOODFALL_TEMPLE) || setting(openDungeonsMm, WF))"
+    "Woodfall Temple Princess Jail": "event(CLEAN_SWAMP) && woodfall_raised"
     "Woodfall Near Fairy Fountain": "event(CLEAN_SWAMP) && short_hook_anywhere"
   locations:
     "Woodfall Entrance Chest": "has(MASK_DEKU) || can_hookshot || event(CLEAN_SWAMP) || can_use_nayru"
@@ -1533,17 +1533,17 @@
   region: WOODFALL
   exits:
     "Woodfall Temple": "true"
-    "Woodfall Shrine": "cond(setting(openDungeonsMm, WF), has(MASK_DEKU) || hookshot_anywhere, true)"
+    "Woodfall Shrine": "cond(setting(openDungeonsMm, WF) || setting(clearStateDungeonsMm, WF), has(MASK_DEKU) || hookshot_anywhere, true)"
     "Woodfall": "event(CLEAN_SWAMP)"
 "Woodfall Shrine":
   region: WOODFALL
   exits:
     "Woodfall": "(has(MASK_DEKU) && soul_deku_scrub) || event(CLEAN_SWAMP) || hookshot_anywhere || can_use_nayru"
     "Woodfall Near Fairy Fountain": "(has(MASK_DEKU) && (soul_deku_scrub || event(CLEAN_SWAMP) || short_hook_anywhere)) || hookshot_anywhere"
-    "Woodfall Front of Temple": "event(OPEN_WOODFALL_TEMPLE) && (has(MASK_DEKU) || hookshot_anywhere)"
+    "Woodfall Front of Temple": "woodfall_raised || hookshot_anywhere"
     "Owl Woodfall": "true"
   events:
-    OPEN_WOODFALL_TEMPLE: "(has(MASK_DEKU) && can_play_awakening) || setting(openDungeonsMm, WF)"
+    OPEN_WOODFALL_TEMPLE: "has(MASK_DEKU) && can_play_awakening"
   locations:
     "Woodfall Near Owl Chest": "short_hook_anywhere"
 "Woodfall Near Fairy Fountain":
@@ -1996,8 +1996,8 @@
   region: SNOWHEAD
   exits:
     "Path to Snowhead Back": "true"
-    "Snowhead": "event(OPEN_SNOWHEAD_TEMPLE) || (setting(openDungeonsMm, SH) && has_mask_goron)"
-    "Snowhead Near Fairy Fountain": "event(OPEN_SNOWHEAD_TEMPLE) || (setting(openDungeonsMm, SH) && has_mask_goron)"
+    "Snowhead": "blizzard_stopped && has_mask_goron)"
+    "Snowhead Near Fairy Fountain": "blizzard_stopped && has_mask_goron)"
     "Owl Snowhead": "true"
   events:
     OPEN_SNOWHEAD_TEMPLE: "can_lullaby || (event(BOSS_SNOWHEAD) && has_mask_goron)"
@@ -2010,15 +2010,15 @@
   exits:
     "Snowhead Entrance": "true"
     "Snowhead Temple": "true"
-    "Snowhead Near Fairy Fountain": "event(BOSS_SNOWHEAD) || setting(openDungeonsMm, SH)"
+    "Snowhead Near Fairy Fountain": "blizzard_stopped"
 "Snowhead Near Fairy Fountain":
   region: SNOWHEAD
   events:
-    MAGIC: "((event(OPEN_SNOWHEAD_TEMPLE) || setting(openDungeonsMm, SH)) && can_break_boulders) || event(BOSS_SNOWHEAD)"
-    RUPEES: "((event(OPEN_SNOWHEAD_TEMPLE) || setting(openDungeonsMm, SH)) || event(BOSS_SNOWHEAD)) && (can_use_light_arrows && soul_wolfos)"
+    MAGIC: "(blizzard_stopped && can_break_boulders) || event(BOSS_SNOWHEAD)"
+    RUPEES: "blizzard_stopped && can_use_light_arrows && soul_wolfos"
   exits:
     "Snowhead Entrance": "true"
-    "Snowhead": "event(BOSS_SNOWHEAD) || setting(openDungeonsMm, SH)"
+    "Snowhead": "blizzard_stopped"
     "Snowhead Fairy Fountain": "true"
 "Snowhead Fairy Fountain":
   region: ENTRANCE
@@ -2571,7 +2571,7 @@
   exits:
     "Zora Cape": "has_mask_zora || can_use_nayru || trick(MM_ZORA_HALL_HUMAN)"
     "Zora Hall": "true"
-    "Great Bay Temple": "((has_mask_zora && can_play_zora) || setting(openDungeonsMm, GB)) && can_hookshot"
+    "Great Bay Temple": "turtle_woken && can_hookshot"
     "Owl Zora Cape": "true"
 "Behind Gorman Fence":
   region: MILK_ROAD

--- a/packages/data/src/world/mm/overworld.yml
+++ b/packages/data/src/world/mm/overworld.yml
@@ -1996,8 +1996,8 @@
   region: SNOWHEAD
   exits:
     "Path to Snowhead Back": "true"
-    "Snowhead": "blizzard_stopped && has_mask_goron)"
-    "Snowhead Near Fairy Fountain": "blizzard_stopped && has_mask_goron)"
+    "Snowhead": "blizzard_stopped && has_mask_goron"
+    "Snowhead Near Fairy Fountain": "blizzard_stopped && has_mask_goron"
     "Owl Snowhead": "true"
   events:
     OPEN_SNOWHEAD_TEMPLE: "can_lullaby || (event(BOSS_SNOWHEAD) && has_mask_goron)"

--- a/packages/data/src/world/mm/overworld.yml
+++ b/packages/data/src/world/mm/overworld.yml
@@ -1533,7 +1533,7 @@
   region: WOODFALL
   exits:
     "Woodfall Temple": "true"
-    "Woodfall Shrine": "cond(setting(openDungeonsMm, WF) || setting(clearStateDungeonsMm, WF), has(MASK_DEKU) || hookshot_anywhere, true)"
+    "Woodfall Shrine": "cond(setting(openDungeonsMm, WF) || setting(clearStateDungeonsMm, WF) || setting(clearStateDungeonsMm, both), has(MASK_DEKU) || hookshot_anywhere, true)"
     "Woodfall": "event(CLEAN_SWAMP)"
 "Woodfall Shrine":
   region: WOODFALL


### PR DESCRIPTION
Adds a setting to open Woodfall Temple and/or Great Bay Temple during their clear states. These settings are overridden by the Open Dungeons (MM) setting by nature.