### PR TITLE
Fix being able to toggle an inventory slot even when you only have one item in the slot.

### DIFF
--- a/packages/core/src/mm/ovl/kaleido_scope.c
+++ b/packages/core/src/mm/ovl/kaleido_scope.c
@@ -21,7 +21,7 @@ void KaleidoScope_AfterSetCutsorColor(GameState_Play* play)
     u32 flags;
     const u8* table;
     u32 tableSize;
-    if (comboGetSlotExtras(cursorSlot, &itemPtr, &flags, &table, &tableSize) >= 0 && play->pauseCtx.cursorItem[0] != 999 && popcount(flags))
+    if (comboGetSlotExtras(cursorSlot, &itemPtr, &flags, &table, &tableSize) >= 0 && play->pauseCtx.cursorItem[0] != 999 && popcount(flags) > 1)
     {
         play->pauseCtx.cursorColorIndex = 4;
         if (press)

--- a/packages/core/src/oot/ovl/kaleido_scope.c
+++ b/packages/core/src/oot/ovl/kaleido_scope.c
@@ -40,7 +40,7 @@ static int checkItemToggle(GameState_Play* play)
     u32 flags;
     const u8* table;
     u32 tableSize;
-    if (comboGetSlotExtras(itemCursor, &itemPtr, &flags, &table, &tableSize) >= 0 && play->pauseCtx.cursorItem[0] != 999 && popcount(flags))
+    if (comboGetSlotExtras(itemCursor, &itemPtr, &flags, &table, &tableSize) >= 0 && play->pauseCtx.cursorItem[0] != 999 && popcount(flags) > 1)
     {
         ret = 1;
         if (press)


### PR DESCRIPTION
Dunno why I thought `popcount(...) > 1` and `popcount(...)` were equivalent.