### PR TITLE
FW Refactor and Void Warp in MM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Add a trick for using Hookshot anywhere to access the Zora Hall doors.
 - Add logic for getting to the Ikana Castle Exterior entrance from the roof.
 - Add logic for soaring out of MM's mini-dungeons.
+- Add a setting to enable Void Warp in MM.
 
 ### Changed
 
@@ -20,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Make bombchu bag and hints play a little nicer.
 - Change OoT boss room death/respawn behavior slightly to avoid gaining out of logic access to market.
 - Made logic surrounding Evan simpler; now requires getting through the door in cursed state or Farore's Wind.
+- Refactor Farore's Wind in MM to make the code more similar to OoT's code.
 
 ### Fixed
 

--- a/packages/core/include/combo/mm/save.h
+++ b/packages/core/include/combo/mm/save.h
@@ -208,9 +208,9 @@ typedef struct
     MmItemEquips            itemEquips;
     MmInventory             inventory;
     MmPermanentSceneFlags   permanentSceneFlags[120];
-    FaroresWindData         fw;
+    RespawnData             fw;
     RespawnData             fwRespawnTop;
-    u8                      unk_E60[0xC];
+    u8                      unk_E58[0x14];
     u32                     dekuPlaygroundHighScores[3];
     u32                     pictoFlags0;
     u32                     pictoFlags1;

--- a/packages/core/lib/combo/patch-build/group.ts
+++ b/packages/core/lib/combo/patch-build/group.ts
@@ -47,6 +47,7 @@ export const PATCH_GROUPS = [
   'MM_OPEN_STT',
   'CRIT_WIGGLE_DISABLE',
   'OOT_LOST_WOODS_EXITS',
+  'MM_VOID_WARP',
 ] as const;
 
 export type PatchGroup = typeof PATCH_GROUPS[number];

--- a/packages/core/lib/combo/patch-build/index.ts
+++ b/packages/core/lib/combo/patch-build/index.ts
@@ -74,6 +74,7 @@ function asmPatchGroups(world: World, settings: Settings) {
     MM_OPEN_STT: world.resolvedFlags.openDungeonsMm.has('ST'),
     CRIT_WIGGLE_DISABLE: settings.critWiggleDisable,
     OOT_LOST_WOODS_EXITS: settings.alterLostWoodsExits,
+    MM_VOID_WARP: settings.voidWarpMm,
   };
   const keys = Object.keys(groups) as PatchGroup[];
   return keys.filter((k) => groups[k]);

--- a/packages/core/lib/combo/settings/data.ts
+++ b/packages/core/lib/combo/settings/data.ts
@@ -1029,6 +1029,13 @@ export const SETTINGS = [{
   description: 'There are unused exits in the Lost Woods that return you to the lost woods. When this is on, all the "got lost" exits in the Lost Woods that would normally take you to Kokiri Forest instead take you back to the Lost Woods, keeping your compass direction intact.',
   default: false
 }, {
+  key: 'voidWarpMm',
+  name: 'Void Warp in MM',
+  category: 'main.misc',
+  type: 'boolean',
+  description: 'In vanilla OoT, various code only checks for transitionTrigger, but in MM it also checks for transitionMode. When this is on, MM will no longer check transitionMode in those circumstances.',
+  default: false
+}, {
   key: 'autoInvert',
   name: 'Auto-Invert Time (MM)',
   category: 'main.misc',

--- a/packages/core/src/mm/actors/En/En_Torch2.S
+++ b/packages/core/src/mm/actors/En/En_Torch2.S
@@ -1,0 +1,11 @@
+#include <combo.h>
+
+/* Remove call to reset respawn data. It was unused anyway. */
+
+/*
+Replaces:
+  jal     Play_SetRespawnData
+*/
+PATCH_START 0x808a3284
+  nop
+PATCH_END

--- a/packages/core/src/mm/actors/Player.S
+++ b/packages/core/src/mm/actors/Player.S
@@ -837,6 +837,26 @@ PATCH_START 0x80848708
   nop
 PATCH_END
 
+/* Enable Void Warp */
+
+PATCH_GROUP PG_MM_VOID_WARP
+
+/*
+Replaces:
+  bnez    v0, .+0x10
+  nop
+  lbu     v0, 0xb4a (v1)
+  sltu    v0, zero, v0
+*/
+PATCH_START 0x8082daa4
+  nop
+  nop
+  nop
+  nop
+PATCH_END
+
+PATCH_GROUP_END
+
 /* Change child link object to use EnvColor instead of PrimColor */
 
 PATCH_VROM 0x01166390

--- a/packages/core/src/mm/actors/Player.S
+++ b/packages/core/src/mm/actors/Player.S
@@ -827,6 +827,16 @@ PATCH_START 0x8083D614
   bnez      v0, .+0x4c
 PATCH_END
 
+/* Remove call for Elegy Statues to set respawn data. It's unused anyway. */
+
+/*
+Replaces:
+  jal       Play_SetupRespawnPoint
+*/
+PATCH_START 0x80848708
+  nop
+PATCH_END
+
 /* Change child link object to use EnvColor instead of PrimColor */
 
 PATCH_VROM 0x01166390

--- a/packages/core/src/mm/ovl/play.c
+++ b/packages/core/src/mm/ovl/play.c
@@ -339,6 +339,42 @@ void hookPlay_Init(GameState_Play* play)
     g.keatonGrassMax = -1;
     comboMultiResetWisps();
 
+    if (gSaveContext.respawnFlag == 8)
+    {
+        s32 fwSceneId = Entrance_GetSceneIdAbsolute(gSaveContext.respawn[RESPAWN_MODE_HUMAN].entrance);
+        Vec3f* pos = &gSaveContext.respawn[RESPAWN_MODE_HUMAN].pos;
+        if (fwSceneId == SCE_MM_GORON_VILLAGE_SPRING || fwSceneId == SCE_MM_GORON_VILLAGE_WINTER)
+        {
+            if (MM_GET_EVENT_WEEK(EV_MM_WEEK_DUNGEON_SH) && pos->x > 1100.0f) // from Lens Cave
+            {
+                // spawn near the owl area instead
+                pos->x = 1189.0f;
+                pos->z = -911.0f;
+            }
+        }
+        else if (fwSceneId == SCE_MM_WOODFALL)
+        {
+            if (!MM_GET_EVENT_WEEK(EV_MM_WEEK_WOODFALL_TEMPLE_RISE) && ABS(pos->z) < 500.0f)
+            {
+                if (pos->z > 0) // from front of temple
+                {
+                    // spawn at owl statue instead
+                    pos->x = 1.0f;
+                    pos->y = 200.0f;
+                    pos->z = 1094.0f;
+                }
+                else // from back of temple
+                {
+                    // spawn near exit to southern swamp instead
+                    pos->x = -41.0f;
+                    pos->y = 12.0f;
+                    pos->z = -1353.0f;
+                }
+            }
+        }
+        gSave.fw.pos = *pos;
+    }
+
     if (!gCustomKeep)
     {
         comboLoadCustomKeep();


### PR DESCRIPTION
- Remove calls to sets respawn data from code related to elegy statues, which wasn't used, to make the other respawn modes available to use.
- Change FW in MM to use a distinct respawn mode to make it more like OoT code. Stop using FaroresWindData struct because it's needlessly large.
- Add setting to enable void warping in MM.