### PR TITLE
Dungeon Rewards fix when using one game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Fix Koume/Kotake still giving red potions when they shouldn't.
 - Fix damage being wrong against Dead Hand in some cases.
 - Fix death after leaving a grotto in MM in ER leading to wrong warps in some cases.
+- Fix an issue with rewards within dungeons using only OOT or only MM.
 
 ## [22.0] - 2024-04-24
 

--- a/packages/core/lib/combo/logic/solve.ts
+++ b/packages/core/lib/combo/logic/solve.ts
@@ -224,6 +224,33 @@ const REWARDS_DUNGEONS = [
   'SS',
 ];
 
+const REWARDS_DUNGEONS_OOT = [
+  'DT',
+  'DC',
+  'JJ',
+  'Forest',
+  'Fire',
+  'Water',
+  'Shadow',
+  'Spirit',
+  'BotW',
+  'IC',
+  'GTG',
+];
+
+const REWARDS_DUNGEONS_MM = [
+  'WF',
+  'SH',
+  'GB',
+  'ST',
+  'SSH',
+  'OSH',
+  'PF',
+  'BtW',
+  'ACoI',
+  'SS',
+];
+
 type ItemPools = {
   extra: PlayerItems,
   required: PlayerItems,
@@ -933,7 +960,15 @@ export class LogicPassSolver {
   private placeDungeonRewardsInDungeons() {
     const allDungeons: Set<string>[] = [];
     for (let i = 0; i < this.input.settings.players; ++i) {
-      allDungeons.push(new Set([...REWARDS_DUNGEONS]));
+      if (this.input.settings.games === 'oot') {
+        allDungeons.push(new Set([...REWARDS_DUNGEONS_OOT]));
+      }
+      if (this.input.settings.games === 'mm') {
+        allDungeons.push(new Set([...REWARDS_DUNGEONS_MM]));
+      }
+      else {
+        allDungeons.push(new Set([...REWARDS_DUNGEONS]));
+      }
     }
 
     const rewards = shuffle(this.input.random, countMapArray(this.state.pools.required)

--- a/packages/core/lib/combo/logic/solve.ts
+++ b/packages/core/lib/combo/logic/solve.ts
@@ -200,30 +200,6 @@ const DUNGEON_ITEMS = {
   Moon: [],
 }
 
-const REWARDS_DUNGEONS = [
-  'DT',
-  'DC',
-  'JJ',
-  'Forest',
-  'Fire',
-  'Water',
-  'Shadow',
-  'Spirit',
-  'WF',
-  'SH',
-  'GB',
-  'ST',
-  'BotW',
-  'IC',
-  'GTG',
-  'SSH',
-  'OSH',
-  'PF',
-  'BtW',
-  'ACoI',
-  'SS',
-];
-
 const REWARDS_DUNGEONS_OOT = [
   'DT',
   'DC',
@@ -967,7 +943,7 @@ export class LogicPassSolver {
         allDungeons.push(new Set([...REWARDS_DUNGEONS_MM]));
       }
       else {
-        allDungeons.push(new Set([...REWARDS_DUNGEONS]));
+        allDungeons.push(new Set([...REWARDS_DUNGEONS_OOT, ...REWARDS_DUNGEONS_MM]));
       }
     }
 


### PR DESCRIPTION
Removes the full list of dungeons for rewards, and replaces it with two separate ones per game. If a non-ootmm option is chosen for the Games setting, it uses that game's list of dungeons; otherwise, it uses both.