### PR TITLE
Vertically align Settings card contents to the top.

### DIFF
--- a/packages/gui/app/style/form.css
+++ b/packages/gui/app/style/form.css
@@ -17,6 +17,7 @@ form.vertical {
 label {
   display: flex;
   align-items: center;
+  align-content: flex-start;
   font-size: 1em;
   flex-wrap: wrap;
   margin: var(--margin);


### PR DESCRIPTION
This avoids the situation that one card in a row getting taller causes wonky layout changes to other, less-dense Settings cards in the row caused by Flex layout automatically placing vertical space between tags.