### PR TITLE
fix: Correct spelling mistake with Megaton Hammer

### DIFF
--- a/packages/core/lib/combo/settings/data.ts
+++ b/packages/core/lib/combo/settings/data.ts
@@ -1734,7 +1734,7 @@ export const SETTINGS = [{
   name: "Megaton Hammer (MM)",
   category: 'items.extensions',
   type: 'boolean',
-  description: "Adds Megaton Hammmr in Majora's Mask.",
+  description: "Adds Megaton Hammer in Majora's Mask.",
   default: false,
   cond: hasMM,
 }, {


### PR DESCRIPTION
Correct a spelling mistake in the tool-tip for the new MM megaton hammer feature.