### PR TITLE
Prevent saving in MM while a text box is open 

### DIFF
--- a/packages/core/src/common/kaleido_scope.c
+++ b/packages/core/src/common/kaleido_scope.c
@@ -94,19 +94,39 @@ s32 KaleidoScope_Update(PlayState* play)
         case 0: /* PAUSE_MAIN_STATE_IDLE */
         case 5: /* PAUSE_MAIN_STATE_SONG_PROMPT */
         case 8: /* PAUSE_MAIN_STATE_IDLE_CURSOR_ON_SONG */
-#if defined(GAME_MM)
-            u16 shouldSave = !pauseCtx->itemDescriptionOn && (buttons & B_BUTTON);
-#else
-            u16 shouldSave = (buttons & B_BUTTON);
-#endif
-            if (shouldSave && KaleidoScope_CanSave(play))
+            if (KaleidoScope_CanSave(play))
             {
-                PlaySound(NA_SE_SY_DECIDE);
-                PlayerDisplayTextBox(play, 0, NULL);
-                saveMessage(play);
-                pauseCtx->state = 7; /* PAUSE_STATE_SAVE_PROMPT */
-                pauseCtx->savePromptState = 0;
-                return 1;
+                u16 shouldSave = (buttons & B_BUTTON);
+#if defined (GAME_MM)
+                if (play->msgCtx.msgLength != 0)
+                {
+                    if (gSaveContext.buttonStatus[0] != BTN_DISABLED)
+                    {
+                        gSaveContext.buttonStatus[0] = BTN_DISABLED;
+                        gSaveContext.hudVisibility = HUD_VISIBILITY_IDLE;
+                        Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
+                    }
+                    if (shouldSave)
+                    {
+                        return 1;
+                    }
+                }
+                else if (gSaveContext.buttonStatus[0] == BTN_DISABLED)
+                {
+                    gSaveContext.buttonStatus[0] = BTN_ENABLED;
+                    gSaveContext.hudVisibility = HUD_VISIBILITY_IDLE;
+                    Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
+                }
+#endif
+                if (shouldSave)
+                {
+                    PlaySound(NA_SE_SY_DECIDE);
+                    PlayerDisplayTextBox(play, 0, NULL);
+                    saveMessage(play);
+                    pauseCtx->state = 7; /* PAUSE_STATE_SAVE_PROMPT */
+                    pauseCtx->savePromptState = 0;
+                    return 1;
+                }
             }
             break;
         }

--- a/packages/core/src/mm/ovl_patch/kaleido_scope.S
+++ b/packages/core/src/mm/ovl_patch/kaleido_scope.S
@@ -221,6 +221,22 @@ PATCH_START 0x808241e4
   li    a3, 0x40
 PATCH_END
 
+PATCH_START 0x808219d4
+  nop
+PATCH_END
+
+PATCH_START 0x80821a50
+  nop
+PATCH_END
+
+PATCH_START 0x80821d54
+  nop
+PATCH_END
+
+PATCH_START 0x808288c4
+  nop
+PATCH_END
+
 /*
   Long series of patches for shifting magic arrow unique select item ID to allow more custom items
 */


### PR DESCRIPTION
This is to prevent softlocking by saving when an NPC asks you to trade an item.