### PR TITLE
Fix logic for pots in upper Deku Palace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Fix a bug where magical rupee would sometimes require a scene reload to work properly.
 - Fix an odd interaction between open MM dungeons and the moon crash.
 - Fix Ganondorf and Ganon fight not allowing Return to Dungeon Entrance.
+- Fix logic for pots in upper Deku Palace.
 
 ## [27.0] - 2025-01-04
 

--- a/packages/data/src/world/mm/overworld.yml
+++ b/packages/data/src/world/mm/overworld.yml
@@ -1577,8 +1577,8 @@
     "Deku Palace Near Cage": "has(MASK_DEKU) || short_hook_anywhere"
     "Deku Palace Corner Ledge Top": "has(MASK_DEKU)"
   locations:
-    "Deku Palace Pot 1": "true"
-    "Deku Palace Pot 2": "true"
+    "Deku Palace Pot 1": "has(MASK_DEKU) || short_hook_anywhere"
+    "Deku Palace Pot 2": "has(MASK_DEKU) || short_hook_anywhere"
 "Deku Palace Throne":
   region: DEKU_PALACE
   exits:


### PR DESCRIPTION
I found a logic bug in a seed in December (see Discord conversation here https://discord.com/channels/1004394204992118935/1045066945512345692/1312711726772391956). The correct logic is in place for the magic in Upper Deku Palace. However, the rule for the pots still reads 'true', even though Deku Mask or short_hook_anywhere is required.