### PR TITLE
Clarify Majora Child Requirements Help Text

### DIFF
--- a/packages/core/lib/combo/settings/data.ts
+++ b/packages/core/lib/combo/settings/data.ts
@@ -1135,8 +1135,8 @@ export const SETTINGS = [{
   type: 'enum',
   description: 'Controls the requirements to enter Majora\'s arena',
   values: [
-    { value: 'none', name: 'None', description: 'As soon as you have access to the Moon you can enter Majora\'s arena' },
-    { value: 'custom', name: 'Custom', description: 'You will need to meet a special condition to enter Majora\'s arena' },
+    { value: 'none', name: 'None', description: 'As soon as you have satisfied the "Moon Access" special condition you can enter Majora\'s arena' },
+    { value: 'custom', name: 'Custom', description: 'You will need to meet the "Majora Child Requirements" special condition to enter Majora\'s arena' },
   ],
   default: 'none',
   cond: (s: any) => hasMM(s) && s.goal !== 'triforce' && s.goal !== 'triforce3',


### PR DESCRIPTION
I was pretty confused by the Majora Child Requirements help text in the Events page of the seed generator. As written, if you aren't familiar with the Special Conditions functionality, it is easy to expect that the special conditions only apply if you are in custom mode. Further, it is possible to interpret the none option as meaning that no special requirements are needed to get to the moon at all.

This change clarifies that both cases have special conditions and leads the user toward the special conditions page in both cases.