### PR TITLE
Update data.ts - single game ER bandaid

### DIFF
--- a/packages/core/lib/combo/settings/data.ts
+++ b/packages/core/lib/combo/settings/data.ts
@@ -2776,7 +2776,7 @@ export const SETTINGS = [{
   type: 'boolean',
   description: 'Shuffle the Mask Shop & Clock Tower entrances among the other indoors.',
   default: false,
-  cond: (x: any) => x.erIndoors === 'full' && (!x.erMixedIndoors || x.erMixed === 'full'),
+  cond: (x: any) => hasOoTMM(x) && (x.erIndoors === 'full' && (!x.erMixedIndoors || x.erMixed === 'full')),
 }, {
   key: 'erWarps',
   name: 'Shuffle Warp Songs and Soaring Spots',


### PR DESCRIPTION
bandaid solution for er issue when trying to gen single-game seed and enabling this setting. Proper solution will be needed rather than just hiding the setting, but I didn't want this to continue to get buried again and again.