### PR TITLE
Better error message for the 'too many items' issue.

### DIFF
--- a/packages/core/lib/combo/logic/solve.ts
+++ b/packages/core/lib/combo/logic/solve.ts
@@ -1319,7 +1319,7 @@ export class LogicPassSolver {
     for (const item of items) {
       if (locations.length === 0) {
         if (required) {
-          throw new Error('Too many items');
+          throw new Error('There are more items than places to put them. Try reducing the number of items or increasing the number of places where items can be placed (e.g. add more shuffles).');
         }
         break;
       }


### PR DESCRIPTION
When generating a seed on ootmm.com, some people add too many items into the pool. They are then presented with the cryptic error message 'too many items'. To some users, this isn't a good enough explanation.

This PR changes the error message to be clearer and suggests ways to fix the issue.

I have not made any checks to ensure that this error can't pop up under other circumstances, nor have I ensured the two suggested ways to fix the issue are the only ways, but hopefully it's at an improvement on the current message.
