### PR TITLE
Adjusted Blitz presets to add Shared Spin Attack Upgrade, Shared Sticks and Nuts Upgrades

### DIFF
--- a/packages/core/lib/combo/presets.ts
+++ b/packages/core/lib/combo/presets.ts
@@ -51,6 +51,7 @@ const BLITZ_BASE: PartialDeep<Settings> = {
   spellLoveMm: true,
   hammerMm: true,
   spinUpgradeOot: true,
+  sharedNutsSticks: true,
   sharedBows: true,
   sharedBombBags: true,
   sharedMagic: true,

--- a/packages/core/lib/combo/presets.ts
+++ b/packages/core/lib/combo/presets.ts
@@ -36,6 +36,7 @@ const BLITZ_BASE: PartialDeep<Settings> = {
   crossWarpMm: 'full',
   fastBunnyHood: true,
   bottleContentShuffle: true,
+  sticksNutsUpgradesMm: true,
   blueFireArrows: true,
   sunlightArrows: true,
   progressiveGoronLullaby: 'single',
@@ -49,6 +50,7 @@ const BLITZ_BASE: PartialDeep<Settings> = {
   spellWindMm: true,
   spellLoveMm: true,
   hammerMm: true,
+  spinUpgradeOot: true,
   sharedBows: true,
   sharedBombBags: true,
   sharedMagic: true,
@@ -94,14 +96,15 @@ const BLITZ_BASE: PartialDeep<Settings> = {
   keepItemsReset: true,
   shadowFastBoat: true,
   songOfDoubleTimeOot: true,
+  sharedSpinUpgrade: true,
   mmPreActivatedOwls: {
     type: 'specific',
     values: ["clocktown"]
   },
   startingItems: {
-    OOT_NUTS_10: 2,
+    SHARED_NUTS_10: 2,
     OOT_SHIELD_DEKU: 1,
-    OOT_STICK: 10,
+    SHARED_STICKS: 10,
     MM_SONG_EPONA: 1,
     SHARED_SHIELD_HYLIAN: 1,
     MM_OCARINA: 1,


### PR DESCRIPTION
Apparently this was something I had forgotten to eventually ask about changing so I decided to try making the changes myself. I think I wanted to see how Spin Attack Upgrade felt in OOT before adding it. Hopefully didn't mess up.