### PR TITLE
Fixed Water Temple

### DIFF
--- a/packages/data/src/world/oot/dungeons/water_temple.yml
+++ b/packages/data/src/world/oot/dungeons/water_temple.yml
@@ -1,8 +1,8 @@
 "Water Temple":
   dungeon: Water
   exits:
-    "Lake Hylia Near Water Temple": "true"
-    "Water Temple Main": "true"
+    "Lake Hylia Near Water Temple": "can_swim_or_sink"
+    "Water Temple Main": "can_swim"
 
 "Water Temple Main":
   dungeon: Water


### PR DESCRIPTION
Fixed The exits of Water Temple Region

Lake Hylia exit can swim or sink due you can equip iron boots and walk out during pausing or dpad