### PR TITLE
Adjusted Bomber's Hideout Chest logic

### DIFF
--- a/packages/data/src/world/mm/overworld/clock_town.yml
+++ b/packages/data/src/world/mm/overworld/clock_town.yml
@@ -208,7 +208,7 @@
     MAGIC: "true"
     RUPEES: "true"
   locations:
-    "Astral Observatory Passage Chest": "has_explosives || trick_keg_explosives"
+    "Astral Observatory Passage Chest": "(has_explosives || trick_keg_explosives) && (can_swim || is_tall)"
     "Astral Observatory Passage Pot 1": "true"
     "Astral Observatory Passage Pot 2": "true"
     "Astral Observatory Passage Pot 3": "true"


### PR DESCRIPTION
Accounting for Bronze Scale, this chest needed its logic to be adjusted. The rest of the area is fine.