### PR TITLE
Updated Laundry Pool for Bronze Scale

### DIFF
--- a/packages/data/src/world/mm/overworld/clock_town.yml
+++ b/packages/data/src/world/mm/overworld/clock_town.yml
@@ -238,9 +238,9 @@
     "Clock Town Laundry Pool Grass 1": "true"
     "Clock Town Laundry Pool Grass 2": "true"
     "Clock Town Laundry Pool Grass 3": "true"
-    "Clock Town Laundry Pool Rupee 1": "is_night2"
-    "Clock Town Laundry Pool Rupee 2": "is_night2"
-    "Clock Town Laundry Pool Rupee 3": "is_night2"
+    "Clock Town Laundry Pool Rupee 1": "is_night2 && can_swim_or_sink"
+    "Clock Town Laundry Pool Rupee 2": "is_night2 && can_swim_or_sink"
+    "Clock Town Laundry Pool Rupee 3": "is_night2 && can_swim_or_sink"
 
 "Clock Town Fairy Fountain":
   region: ENTRANCE


### PR DESCRIPTION
The three freestanding red rupees in Laundry Pool under the water were missed in the initial Bronze Scale logic. They now appropriately account for needing either the ability to swim or Iron Boots/Zora to be able to obtain them.