### PR TITLE
Blitz Preset Updates

### DIFF
--- a/packages/core/lib/combo/presets.ts
+++ b/packages/core/lib/combo/presets.ts
@@ -37,6 +37,7 @@ const BLITZ_BASE: PartialDeep<Settings> = {
   bottleContentShuffle: true,
   sticksNutsUpgradesMm: true,
   blueFireArrows: true,
+  iceArrowPlatformsOot: true,
   sunlightArrows: true,
   progressiveGoronLullaby: 'single',
   freeScarecrowOot: true,
@@ -91,6 +92,7 @@ const BLITZ_BASE: PartialDeep<Settings> = {
   agelessChildTrade: true,
   scalesMm: true,
   strengthMm: true,
+  kegStrength3: true,
   sharedScales: true,
   sharedStrength: true,
   keepItemsReset: true,
@@ -261,9 +263,9 @@ const PRESET_TRIFORCE_BLITZ = makeBlitz({
   strayFairyChestShuffle: "starting",
   rainbowBridge: 'custom',
   preCompletedDungeons: true,
-  preCompletedDungeonsMajor: 6,
+  preCompletedDungeonsMajor: 8,
   preCompletedDungeonsStones: 2,
-  preCompletedDungeonsMedallions: 2,
+  preCompletedDungeonsMedallions: 4,
   preCompletedDungeonsRemains: 2,
   junkLocations: [
     "MM Beneath The Graveyard Dampe Chest",
@@ -278,7 +280,6 @@ const PRESET_TRIFORCE_BLITZ = makeBlitz({
     "MM Ocean Spider House Wallet",
     "MM Pinnacle Rock HP",
     "MM Snowhead Great Fairy",
-    "MM Stock Pot Inn Couple's Mask",
     "MM Swamp Spider House Mask of Truth",
     "MM Town Archery Reward 2",
     "MM Waterfall Rapids Beaver Race 2",
@@ -288,13 +289,12 @@ const PRESET_TRIFORCE_BLITZ = makeBlitz({
   ],
   specialConds: {
     BRIDGE: {
-      count: 10,
-      stones: true,
-      medallions: true,
-      remains: true
+      count: 0
     },
     MOON: {
-      count: 0
+      count: 7,
+      stones: true,
+      remains: true
     }
   },
   hints: [


### PR DESCRIPTION
Added the following to the Blitz Presets:

-Strength 3 Powder Keg use since  Goron Keg Trial no longer expects Bunny Hood + Longshot in base logic

-OOT Ice Arrow Platforms.

Triforce Blitz got specifically, separately updated with the following changes:

-Reduced dungeons down to there only being 4 dungeons to reduce the check pool

-Opened Ganon's Castle but then locked the Moon behind needing either a stone and a remain OR 2 remains (depends on what rewards you start with). This is to remove the insane amount of "(sometimes required)" players would see in these settings caused by essentially having an open Moon.

-Unjunked Anju and Kafei for only the Triforce Blitz preset.