### PR TITLE
Ice Arrow Platform Logic for Water Temple BK Chest

### DIFF
--- a/packages/data/src/world/oot/dungeons/water_temple.yml
+++ b/packages/data/src/world/oot/dungeons/water_temple.yml
@@ -15,7 +15,7 @@
     "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has_goron_bracelet && can_dive_small && (can_use_sword || has_ranged_weapon || has_explosives_or_hammer)"
     "Water Temple Elevator": "(small_keys_water(5) && (can_hookshot || climb_anywhere)) || can_use_bow || can_use_din"
     "Water Temple Corridor": "(can_longshot || has_hover_boots || hookshot_anywhere) && can_hit_triggers_distance && event(WATER_LEVEL_LOW)"
-    "Water Temple Waterfalls": "has_tunic_zora && small_keys_water(4) && (can_longshot || climb_anywhere || hookshot_anywhere) && (has_iron_boots || event(WATER_LEVEL_LOW))"
+    "Water Temple Waterfalls": "has_tunic_zora && small_keys_water(4) && (can_longshot || can_use_ice_arrow_platforms || climb_anywhere || hookshot_anywhere) && (has_iron_boots || event(WATER_LEVEL_LOW))"
     "Water Temple Large Pit": "small_keys_water(4) && event(WATER_LEVEL_RESET)"
     "Water Temple Antichamber Room": "((can_longshot || can_use_ice_arrow_platforms) && event(WATER_LEVEL_RESET)) || climb_anywhere"
     "Water Temple Cage Room": "has_tunic_zora && event(WATER_LEVEL_LOW) && has_explosives && can_dive_small"

--- a/packages/data/src/world/oot/dungeons_mq/water_temple_mq.yml
+++ b/packages/data/src/world/oot/dungeons_mq/water_temple_mq.yml
@@ -244,7 +244,7 @@
   dungeon: Water
   exits:
     "Water Temple Main Room Bottom Floor": "event(WATER_GATES) && has_iron_boots && has_tunic_zora"
-    "Water Temple Leading To Side Loop After Spikes": "can_longshot || hookshot_anywhere || climb_anywhere"
+    "Water Temple Leading To Side Loop After Spikes": "can_longshot || can_use_ice_arrow_platforms || hookshot_anywhere || climb_anywhere"
 "Water Temple Leading To Side Loop After Spikes":
   dungeon: Water
   exits:


### PR DESCRIPTION
Added Ice Arrow Platform logic to the following rooms in Water Temple:

-Boss Key Chest in Vanilla Water Temple (using the ice arrows to cross over the spikes)

-Ice Arrow Platform logic to the same room in MQ Water Temple, where the player would normally use longshot over the spikes.