### PR TITLE
Water Temple Corridor Ice Arrow logic

### DIFF
--- a/packages/data/src/world/oot/dungeons/water_temple.yml
+++ b/packages/data/src/world/oot/dungeons/water_temple.yml
@@ -14,7 +14,7 @@
     "Water Temple Compass Room": "(has_tunic_zora && has_iron_boots && can_hookshot) || (event(WATER_LEVEL_LOW) && (can_hookshot || climb_anywhere))"
     "Water Temple Dragon Room": "event(WATER_LEVEL_LOW) && has_goron_bracelet && can_dive_small && (can_use_sword || has_ranged_weapon || has_explosives_or_hammer)"
     "Water Temple Elevator": "(small_keys_water(5) && (can_hookshot || climb_anywhere)) || can_use_bow || can_use_din"
-    "Water Temple Corridor": "(can_longshot || has_hover_boots || hookshot_anywhere) && can_hit_triggers_distance && event(WATER_LEVEL_LOW)"
+    "Water Temple Corridor": "(can_longshot || can_use_ice_arrow_platforms || has_hover_boots || hookshot_anywhere) && can_hit_triggers_distance && event(WATER_LEVEL_LOW)"
     "Water Temple Waterfalls": "has_tunic_zora && small_keys_water(4) && (can_longshot || can_use_ice_arrow_platforms || climb_anywhere || hookshot_anywhere) && (has_iron_boots || event(WATER_LEVEL_LOW))"
     "Water Temple Large Pit": "small_keys_water(4) && event(WATER_LEVEL_RESET)"
     "Water Temple Antichamber Room": "((can_longshot || can_use_ice_arrow_platforms) && event(WATER_LEVEL_RESET)) || climb_anywhere"


### PR DESCRIPTION
Added Ice Arrow Platform logic to Water Temple Corridor so now Corridor is Longshot, Ice Arrows, or Hover Boots.