### PR TITLE
Iron Boots and Longshot to reach Upper Ikana Canyon

### DIFF
--- a/packages/data/src/world/mm/overworld/ikana_valley.yml
+++ b/packages/data/src/world/mm/overworld/ikana_valley.yml
@@ -4,7 +4,7 @@
     FAIRY: "can_get_gossip_fairy"
   exits:
     "Road to Ikana Top": "true"
-    "Ikana Canyon": "(((can_use_ice_arrows && soul_octorok) || trick(MM_ICELESS_IKANA)) && can_hookshot) || short_hook_anywhere"
+    "Ikana Canyon": "(((can_use_ice_arrows && soul_octorok) || trick(MM_ICELESS_IKANA)) && can_hookshot) || (has_iron_boots && can_hookshot) || short_hook_anywhere"
     "Sakon Hideout": "event(MEET_KAFEI) && at(NIGHT3_PM_06_00)"
     "Ikana Valley Near Secret Shrine": "can_swim || (can_use_ice_arrows && has_chateau)"
     "Swamp Front": "underwater_walking || can_swim"


### PR DESCRIPTION
Title is self-explanatory. You can reach upper Ikana Canyon by using iron boots in the water and then hooking to the tree. This is possible because iron boots puts you close enough to hook to the tree from below, not needing ice arrows to cross to the dock. This creates a conditional iceless Ikana Canyon if Iron Boots in MM are enabled.

If you need to see the visuals: https://www.twitch.tv/revven91/clip/ToughSparklyTomatoNononoCat-9b5ZK7L2SWuwsNP9