### PR TITLE
Adjusted combat logic to Gerudo Fortress and Ice Cavern

### DIFF
--- a/packages/data/src/world/oot/dungeons/gerudo_fortress.yml
+++ b/packages/data/src/world/oot/dungeons/gerudo_fortress.yml
@@ -33,7 +33,7 @@
     RUPEES: "true"
     CARPENTER_2: "can_rescue_carpenter"
   locations:
-    "Gerudo Fortress Jail 2": "(can_use_sword || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
+    "Gerudo Fortress Jail 2": "(can_use_sword || can_hammer || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
     "Gerudo Member Card": "carpenters_rescued"
     "Gerudo Fortress Pot Jail 2 1": "true"
     "Gerudo Fortress Pot Jail 2 2": "true"
@@ -68,7 +68,7 @@
     RUPEES: "true"
     CARPENTER_4: "can_rescue_carpenter"
   locations:
-    "Gerudo Fortress Jail 4": "(can_use_sword || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
+    "Gerudo Fortress Jail 4": "(can_use_sword || can_hammer || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
     "Gerudo Member Card": "carpenters_rescued"
     "Gerudo Fortress Wonder Item Jail 4 1": "can_use_bow"
     "Gerudo Fortress Wonder Item Jail 4 2": "can_use_bow"
@@ -126,7 +126,7 @@
   events:
     CARPENTER_3: "can_rescue_carpenter"
   locations:
-    "Gerudo Fortress Jail 3": "(can_use_sword || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
+    "Gerudo Fortress Jail 3": "(can_use_sword || can_hammer || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
     "Gerudo Member Card": "carpenters_rescued"
     "Gerudo Fortress Pot Jail 3 1": "true"
     "Gerudo Fortress Pot Jail 3 2": "true"

--- a/packages/data/src/world/oot/dungeons/ice_cavern.yml
+++ b/packages/data/src/world/oot/dungeons/ice_cavern.yml
@@ -2,7 +2,7 @@
   dungeon: IC
   exits:
     "Zora Fountain Frozen": "true"
-    "Ice Cavern Scythe": "soul_freezard && (can_use_sword_master || can_use_sword_goron || can_hammer || can_use_sticks || has_fire || has_explosives)"
+    "Ice Cavern Scythe": "soul_freezard && (can_use_sword_master || can_use_sword_biggoron || can_hammer || can_use_sticks || has_fire || has_explosives)"
     "Ice Cavern End": "has_iron_boots && (climb_anywhere || hookshot_anywhere)"
   locations:
     "Ice Cavern Rupee Ice": "has_blue_fire"


### PR DESCRIPTION
-Added Megaton Hammer as a means to defeat the Gerudo in Jail 1

-Added Megaton Hammer as a means to defeat the first set of Freezards in Ice Cavern

-Added Din's Fire and Fire Arrows (via has_fire macro) as another means to defeat the Freezards in Ice Cavern