### PR TITLE
fix: correct typo Swanp -> Swamp

### DIFF
--- a/packages/data/src/pool/pool_mm.csv
+++ b/packages/data/src/pool/pool_mm.csv
@@ -585,12 +585,12 @@ Road to Southern Swamp Potted Plant 1 Pot,              pot,            NONE,   
 Road to Southern Swamp Potted Plant 1 Grass,            grass,          NONE,                   ROAD_SOUTHERN_SWAMP,          0x10028,                    RECOVERY_HEART
 Road to Southern Swamp Potted Plant 2 Pot,              pot,            NONE,                   ROAD_SOUTHERN_SWAMP,          0x00029,                    NOTHING
 Road to Southern Swamp Potted Plant 2 Grass,            grass,          NONE,                   ROAD_SOUTHERN_SWAMP,          0x10029,                    RECOVERY_HEART
-Road to Southern Swanp Forked Tree 1,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001a,                    NOTHING
-Road to Southern Swanp Forked Tree 2,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001b,                    NOTHING
-Road to Southern Swanp Forked Tree 3,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001c,                    NOTHING
-Road to Southern Swanp Forked Tree 4,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001d,                    NOTHING
-Road to Southern Swanp Forked Tree 5,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001e,                    NOTHING
-Road to Southern Swanp Forked Tree 6,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001f,                    NOTHING
+Road to Southern Swamp Forked Tree 1,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001a,                    NOTHING
+Road to Southern Swamp Forked Tree 2,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001b,                    NOTHING
+Road to Southern Swamp Forked Tree 3,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001c,                    NOTHING
+Road to Southern Swamp Forked Tree 4,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001d,                    NOTHING
+Road to Southern Swamp Forked Tree 5,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001e,                    NOTHING
+Road to Southern Swamp Forked Tree 6,                   tree,           NONE,                   ROAD_SOUTHERN_SWAMP,          0x0001f,                    NOTHING
 Southern Swamp HP,                                      collectible,    NONE,                   SOUTHERN_SWAMP,               0x1e,                       HEART_PIECE
 Southern Swamp Scrub Deed,                              npc,            NONE,                   SOUTHERN_SWAMP,               SCRUB_SWAMP,                DEED_SWAMP
 Southern Swamp Scrub Shop,                              npc,            NONE,                   SOUTHERN_SWAMP,               SCRUB_SHOP_BEANS,           MAGIC_BEAN

--- a/packages/data/src/world/mm/overworld/road_to_swamp.yml
+++ b/packages/data/src/world/mm/overworld/road_to_swamp.yml
@@ -45,12 +45,12 @@
     "Road to Southern Swamp Potted Plant 1 Grass": "true"
     "Road to Southern Swamp Potted Plant 2 Pot": "true"
     "Road to Southern Swamp Potted Plant 2 Grass": "true"
-    "Road to Southern Swanp Forked Tree 1": "true"
-    "Road to Southern Swanp Forked Tree 2": "true"
-    "Road to Southern Swanp Forked Tree 3": "true"
-    "Road to Southern Swanp Forked Tree 4": "true"
-    "Road to Southern Swanp Forked Tree 5": "true"
-    "Road to Southern Swanp Forked Tree 6": "true"
+    "Road to Southern Swamp Forked Tree 1": "true"
+    "Road to Southern Swamp Forked Tree 2": "true"
+    "Road to Southern Swamp Forked Tree 3": "true"
+    "Road to Southern Swamp Forked Tree 4": "true"
+    "Road to Southern Swamp Forked Tree 5": "true"
+    "Road to Southern Swamp Forked Tree 6": "true"
   gossip:
     "Road to Southern Swamp Gossip": "true"
 


### PR DESCRIPTION
I came across this typo while reading the logic files and thought I'd fix it. I searched the whole repo for "Swanp" to make sure I didn't miss any typos.