### PR TITLE
Boomerang Zora's River Heart Pieces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Make Song of Double Time (OoT) behave like Sun's Song in scenes where reloading in the same position doesn't work correctly.
 - Fix logic for the underwater rocks in Gerudo Valley.
+- Added Boomerang as logic for collecting both of the Zora's River Heart Pieces as it wasn't relevant until animal souls.
 
 ## [30.0] - 2026-03-02
 

--- a/packages/data/src/world/oot/overworld/zora_river.yml
+++ b/packages/data/src/world/oot/overworld/zora_river.yml
@@ -49,8 +49,8 @@
     MAGIC: "true"
   locations:
     "Zora River Bean Seller": "is_child && can_use_wallet(1) && soul_bean_salesman"
-    "Zora River HP Pillar": "(is_child && soul_cucco) || has_hover_boots || climb_anywhere || hookshot_anywhere || glitch_megaflip"
-    "Zora River HP Platform": "(is_child && soul_cucco) || has_hover_boots || climb_anywhere || hookshot_anywhere || glitch_megaflip"
+    "Zora River HP Pillar": "(is_child && soul_cucco) || can_boomerang || has_hover_boots || climb_anywhere || hookshot_anywhere || glitch_megaflip"
+    "Zora River HP Platform": "(is_child && soul_cucco) || can_boomerang || has_hover_boots || climb_anywhere || hookshot_anywhere || glitch_megaflip"
     "Zora River Frogs Storms": "is_child && can_play_storms"
     "Zora River Frogs Zeldas Lullaby": "is_child && can_play_zelda"
     "Zora River Frogs Eponas Song": "is_child && can_play_epona"


### PR DESCRIPTION
Added boomerang to the freestanding Heart Pieces in Zora's River where previously they were assumed to be obtainable with cucco until animal souls were added. Now boomerang is relevant but only when animal souls are shuffled; this was missed for awhile apparently.