### PR TITLE
Revamped and fixed much of Woodfall Temple logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,17 @@ All notable changes to this project will be documented in this file.
 - Add a basic implementation of music categories.
 - Add a setting to avoid placing multiple playthrough hints for identical items.
 
+### Changed
+
+- Revamped Woodfall Temple logic to better account for Bronze Scale and future-proofing for planned features.
+
 ### Fixed
 
 - Fix seeds requiring very early warp songs usage being sometimes unbeatable. (#905)
 - Auto-equip the deku mask when entering deku palace throne in ER if possible to avoid a potential seed brick.
 - Fix Haunted Wasteland Poe Guide being removed when Enemy Souls are on.
 - Fix some areas being dead silent when they should have some ambience noises.
+- Fixed a lot of broken logic for Woodfall Temple, mostly accounting for Bronze Scale.
 
 ## [30.1] - 2026-03-15
 

--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -316,7 +316,7 @@
 "can_kill_keese_close": "soul_keese && (has_weapon || has_arrows || can_hookshot_short || can_use_deku_bubble || can_use_din)"
 "can_kill_tektites": "soul_tektite && (has_arrows || can_fight || has_explosives || deku_stick_fighting)" # unsure if Deku Spins or hookshot damage
 "can_kill_peahats": "soul_peahat && (can_fight || has_arrows || deku_stick_fighting || has(MASK_DEKU)) && is_day"
-"can_kill_lizalfos_dinalfos": "soul_lizalfos_dinalfos && (has_weapon || has_mask_goron || has_arrows)"
+"can_kill_lizalfos_dinolfos": "soul_lizalfos_dinolfos && (has_weapon || has_mask_goron || has_arrows)"
 "can_kill_skulltulas": "soul_skulltula && (can_fight || has_arrows || can_hookshot_short || can_use_din || has_explosives || can_use_deku_bubble || deku_stick_fighting)"
 "can_kill_skullwalltulas": soul_skullwalltula && (has_nuts || can_hammer || has_weapon_range || has_explosives)"
 "can_kill_armos": "soul_armos && (can_fight || has_arrows || can_use_din || has_explosives)" # unsure if Deku Bubble works

--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -242,6 +242,7 @@
 "underwater_walking": "has_mask_zora || (has_tunic_zora && has_iron_boots)"
 "underwater_walking_strict": "has_mask_zora || (has_tunic_zora_strict && has_iron_boots)"
 "cross_poison_swamp": "is_tall || has_mask_goron || (can_swim && (is_swamp_cleared || can_use_nayru)) || has_iron_boots"
+"enter_woodfall_temple_water": "event(WOODFALL_TEMPLE_MAIN_FLOWER) || can_use_nayru"
 
 # Hot water
 "OLD_hot_water(winter, spring)": "has_bottle && ((event(winter) && event(spring)) || (is_winter && event(winter)) || (is_spring && event(spring)))"
@@ -346,7 +347,7 @@
 "can_kill_skullfish": "soul_skull_fish && (has_mask_zora || (has_iron_boots && can_hookshot))"
 "can_kill_wasp": "soul_wasp && (can_fight || has_arrows || can_hookshot || can_use_din || has(MASK_DEKU))" # currently not used anywhere but created for enemy drops
 "can_kill_dexihands": "soul_enemy(SOUL_ENEMY_DEXIHAND) && (has_mask_zora || has_explosives)"
-"can_kill_dragonflies": "soul_enemy(SOUL_ENEMY_DRAGONFLY) && (has(MASK_DEKU) || can_fight || has_nuts || has_arrows || can_use_deku_bubble || can_use_din || has_explosives)"
+"can_kill_dragonflies": "soul_enemy(SOUL_ENEMY_DRAGONFLY) && (has(MASK_DEKU) || can_fight || has_nuts || has_arrows || can_use_din || has_explosives)"
 "can_kill_dragonflies_distance": "soul_enemy(SOUL_ENEMY_DRAGONFLY) && (can_use_deku_bubble || has_arrows || has_mask_zora)"
 "can_kill_eenos": "soul_eenos && (can_fight || has_arrows || can_hookshot || can_use_deku_bubble || has_explosives || deku_stick_fighting)"
 "can_kill_eyegore": "soul_enemy(SOUL_ENEMY_EYEGORE) && (can_fight || has_arrows || can_hookshot_short || can_use_din || has(MASK_DEKU) || has_explosives)"

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -312,7 +312,7 @@
 "can_kill_leevers": "soul_leever && (has_sword || can_hammer || can_use_slingshot || can_use_bow || has_explosives || can_use_din)"
 "can_kill_peahats_ground": "soul_peahat && (can_use_sword_or_sticks || has_arrows || can_hammer || can_hookshot || can_use_slingshot) || (is_night && has_explosives))"
 "can_kill_peahats_high": "soul_peahat && (can_use_slingshot || (is_night && has_explosives))"
-"can_kill_lizalfos_dinalfos": "soul_lizalfos_dinalfos && (can_use_sword_or_sticks || can_hammer || can_use_slingshot || can_use_bow)"
+"can_kill_lizalfos_dinolfos": "soul_lizalfos_dinolfos && (can_use_sword_or_sticks || can_hammer || can_use_slingshot || can_use_bow)"
 "can_kill_larvae_eggs_low": "has_ranged_weapon || has_nuts"    #Can be used for clear rooms, but doesn't give enemy drops in OoTR.
 "can_kill_larvae_eggs_high": "has_ranged_weapon"
 "can_kill_larvae_hatched": "soul_gohma_larvae && (can_use_sword_or_sticks || can_hammer || can_use_slingshot || can_use_bow || can_hookshot || has_explosives || can_use_din)"

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -123,10 +123,12 @@
 "Woodfall Temple Map Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Water Room Map Ledge": "true"
+    "Woodfall Temple Water Room Map Ledge": "event(WFT_MAP_ROOM_ENEMIES)"
     "WARP_SONGS": "true"
+  events:
+    WFT_MAP_ROOM_ENEMIES: "can_kill_snappers_flowers"
   locations:
-    "Woodfall Temple Map": "can_kill_snappers_flowers"
+    "Woodfall Temple Map": "event(WFT_MAP_ROOM_ENEMIES)"
     "Woodfall Temple Grass Map Room 1": "true"
     "Woodfall Temple Grass Map Room 2": "true"
     "Woodfall Temple Grass Map Room 3": "true"
@@ -151,10 +153,12 @@
 "Woodfall Temple Compass Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Maze": "true"
+    "Woodfall Temple Maze": "event(WFT_COMPASS_ROOM_ENEMIES)"
     "WARP_SONGS": "true"
+  events:
+    WFT_COMPASS_ROOM_ENEMIES: "can_kill_dragonflies"
   locations:
-    "Woodfall Temple Compass": "can_kill_dragonflies"
+    "Woodfall Temple Compass": "event(WFT_COMPASS_ROOM_ENEMIES)"
     "Woodfall Temple Grass Compass Room 1": "true"
     "Woodfall Temple Grass Compass Room 2": "true"
     "Woodfall Temple Grass Compass Room 3": "true"
@@ -168,8 +172,9 @@
   events:
     STICKS: "can_kill_baba_sticks"
     NUTS: "can_kill_baba_nuts"
+    WFT_DARK_ROOM_ENEMIES: "can_kill_boes"
   locations:
-    "Woodfall Temple Dark Chest": "can_kill_boes"
+    "Woodfall Temple Dark Chest": "event(WFT_DARK_ROOM_ENEMIES)"
 
 "Woodfall Temple Pits Room":
   dungeon: WF
@@ -231,10 +236,12 @@
 "Woodfall Temple Bow Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Water Room Upper Ledge": "can_kill_lizalfos_dinolfos"
+    "Woodfall Temple Water Room Upper Ledge": "event(WFT_BOW_ROOM_ENEMIES)"
     "WARP_SONGS": "true"
+  events:
+    WFT_BOW_ROOM_ENEMIES: "can_kill_lizalfos_dinolfos"
   locations:
-    "Woodfall Temple Bow": "can_kill_lizalfos_dinolfos"
+    "Woodfall Temple Bow": "event(WFT_BOW_ROOM_ENEMIES)"
 
 "Woodfall Temple Water Room Boss Key Ledge":
   dungeon: WF
@@ -274,6 +281,7 @@
   dungeon: WF
   exits:
     "Woodfall Temple Main Upper Ledge": "true"
+    "Woodfall Temple Pre-Boss Rupee Platform": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && (can_hookshot || is_adult))"
     "Woodfall Temple Pre-Boss Far Ledge": "has(MASK_DEKU) || hookshot_anywhere || (can_hookshot && (can_swim || has_hover_boots || can_use_ice_arrows)) || (has_arrows && short_hook_anywhere)"
     "WARP_SONGS": "true"
   locations:
@@ -286,16 +294,12 @@
     "Woodfall Temple Grass Pre-Boss 3": "true"
     "Woodfall Temple Grass Pre-Boss 4": "true"
     "Woodfall Temple Grass Pre-Boss 5": "true"
-    "Woodfall Temple Rupee Lower 1": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && (can_hookshot || is_adult))"
-    "Woodfall Temple Rupee Lower 2": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && (can_hookshot || is_adult))"
-    "Woodfall Temple Rupee Lower 3": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && is_adult)"
-    "Woodfall Temple Rupee Lower 4": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && is_adult)"
     "Woodfall Temple Rupee Upper Right": "has(MASK_DEKU)"
 
 "Woodfall Temple Pre-Boss Far Ledge":
   dungeon: WF
   exits:
-    "Woodfall Temple Pre-Boss Main Ledge": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+    "Woodfall Temple Pre-Boss Rupee Platform": "true"
     "Woodfall Temple Boss Access": "boss_key(BOSS_KEY_WF)"
     "WARP_SONGS": "true"
   locations:
@@ -312,6 +316,13 @@
     "Woodfall Temple Grass Pre-Boss 3": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
     "Woodfall Temple Grass Pre-Boss 4": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
     "Woodfall Temple Grass Pre-Boss 5": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+
+"Woodfall Temple Pre-Boss Rupee Platform":
+  dungeon: WF
+  exits:
+    "Woodfall Temple Pre-Boss Main Ledge": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+    "Woodfall Temple Pre-Boss Far Ledge": "can_hookshot || (has_arrows && short_hook_anywhere)"
+  locations:
     "Woodfall Temple Rupee Lower 1": "true"
     "Woodfall Temple Rupee Lower 2": "true"
     "Woodfall Temple Rupee Lower 3": "true"

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -103,7 +103,7 @@
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
-    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron))) || (has(MASK_GREAT_FAIRY) && (has_arrows || has_bombchu || can_hookshot))"
+    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)))) || (has(MASK_GREAT_FAIRY) && (has_arrows || has_bombchu || can_hookshot))"
 
 "Woodfall Temple Water Room Map Ledge":
   dungeon: WF
@@ -115,7 +115,7 @@
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
-    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron))) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
+    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)))) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
     "Woodfall Temple Grass Water Room 1": "true"
     "Woodfall Temple Grass Water Room 2": "true"
 
@@ -220,7 +220,7 @@
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || has_hover_boots || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
-    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron))) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
+    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)))) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
     "Woodfall Temple Pot Water Room 1": "true"
     "Woodfall Temple Pot Water Room 2": "true"
     "Woodfall Temple Pot Water Room 3": "true"

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -232,7 +232,7 @@
     "Woodfall Temple Water Room Upper Ledge": "can_kill_lizalfos_dinolfos"
     "WARP_SONGS": "true"
   locations:
-    "Woodfall Temple Bow": "can_kill_lizalfos_dinalfos"
+    "Woodfall Temple Bow": "can_kill_lizalfos_dinolfos"
 
 "Woodfall Temple Water Room Boss Key Ledge":
   dungeon: WF

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -59,7 +59,7 @@
     NUTS: "can_kill_baba_nuts"
   locations:
     "Woodfall Temple Center Chest": "event(WOODFALL_TEMPLE_MAIN_CHEST)"
-    "Woodfall Temple SF Main Deku Baba": "can_kill_baba_nuts || can_kill_baba_both_sticks"
+    "Woodfall Temple SF Main Deku Baba": "can_kill_baba_nuts"
     "Woodfall Temple Grass Main Room 1": "true"
     "Woodfall Temple Grass Main Room 2": "true"
     "Woodfall Temple Grass Main Room 3": "true"
@@ -88,6 +88,7 @@
     ARROWS: "true"
     MAGIC: "true"
   locations:
+    "Woodfall Temple SF Main Pot": "true"
     "Woodfall Temple Pot Main Room Lower 1": "true"
     "Woodfall Temple Pot Main Room Lower 4": "true"
     "Woodfall Temple Pot Main Room Lower 5": "true"

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -3,7 +3,7 @@
   exits:
     "WARP_SONGS": "true"
     "Woodfall Front of Temple": "can_reset_time"
-    "Woodfall Temple Entrance": "can_reset_time_dungeon"
+    "Woodfall Temple Entrance Front": "can_reset_time_dungeon"
 
 "Woodfall Temple Entrance Front":
   dungeon: WF
@@ -196,9 +196,10 @@
   dungeon: WF
   exits:
     "Woodfall Temple Main Entrance Ledge": "has(MASK_DEKU) || short_hook_anywhere || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_hover_boots || has_bombs || has_mask_goron || (can_use_nayru && can_swim) || (event(WOODFALL_TEMPLE_MAIN_CHEST) && can_hookshot)"
+    "Woodfall Temple Main Water Room Ledge": "true"
     "Woodfall Temple Pits Room": "true"
     "Woodfall Temple Pre-Boss Main Ledge": "has_arrows || can_use_din"
-    "Woodfall Temple Water Room Upper": "true"
+    "Woodfall Temple Water Room Upper Ledge": "true"
     "WARP_SONGS": "true"
   events:
     WOODFALL_TEMPLE_MAIN_FLOWER: "has_arrows"

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -5,7 +5,7 @@
     "Woodfall Front of Temple": "can_reset_time"
     "Woodfall Temple Entrance": "can_reset_time_dungeon"
 
-"Woodfall Temple Entrance":
+"Woodfall Temple Entrance Front":
   dungeon: WF
   events:
     MAGIC: "true"
@@ -13,7 +13,7 @@
     FAIRY: "true"
   exits:
     "Woodfall Temple": "true"
-    "Woodfall Temple Main": "has(MASK_DEKU) || can_hookshot_short || (has_hover_boots && has_weapon && has_explosives && has_mask_bunny && (has_arrows || has_mask_stone) && trick(MM_WFT_LOBBY_HOVERS))"
+    "Woodfall Temple Entrance Back": "has(MASK_DEKU) || can_hookshot_short || (has_hover_boots && has_weapon && has_explosives && has_mask_bunny && (has_arrows || has_mask_stone) && trick(MM_WFT_LOBBY_HOVERS))"
     "Woodfall Temple Boss Access": "setting(bossWarpPads, remains) && has(REMAINS_ODOLWA)"
     "WARP_SONGS": "true"
   locations:
@@ -23,57 +23,109 @@
     "Woodfall Temple Grass Entrance Bottom 1": "true"
     "Woodfall Temple Grass Entrance Bottom 2": "true"
     "Woodfall Temple Grass Entrance Bottom 3": "true"
-    "Woodfall Temple Grass Entrance Ledge 1": "has(MASK_DEKU) || can_hookshot_short"
-    "Woodfall Temple Grass Entrance Ledge 2": "has(MASK_DEKU) || can_hookshot_short"
     "Woodfall Temple Hive Entrance": "break_hive"
 
-"Woodfall Temple Main":
+"Woodfall Temple Entrance Back":
+  dungeon: WF
+  events:
+    RUPEES: "has_weapon_range"
+  exits:
+    "Woodfall Temple Entrance Front": "true"
+    "Woodfall Temple Main Entrance Ledge": "true"
+    "WARP_SONGS": "true"
+  locations:
+    "Woodfall Temple Entrance Chest": "can_hookshot || (has(MASK_DEKU) && (can_goron_bomb_jump || short_hook_anywhere))"
+    "Woodfall Temple SF Entrance": "has(MASK_GREAT_FAIRY)"
+    "Woodfall Temple Pot Entrance": "has_weapon_range || has_bombchu"
+    "Woodfall Temple Grass Entrance Bottom 1": "true"
+    "Woodfall Temple Grass Entrance Bottom 2": "true"
+    "Woodfall Temple Grass Entrance Bottom 3": "true"
+    "Woodfall Temple Grass Entrance Ledge 1": "true"
+    "Woodfall Temple Grass Entrance Ledge 2": "true"
+    "Woodfall Temple Hive Entrance": "break_hive"
+
+"Woodfall Temple Main Entrance Ledge":
   dungeon: WF
   exits:
-    "Woodfall Temple Entrance": "true"
-    "Woodfall Temple Water Room": "true"
+    "Woodfall Temple Entrance Back": "true"
+    "Woodfall Temple Main Water Room Ledge": "has(MASK_DEKU) || has_bombs || has_mask_goron || event(WOODFALL_TEMPLE_MAIN_FLOWER) || can_use_ice_arrows || (can_use_nayru && can_swim) || has_hover_boots || can_hookshot_short"
     "Woodfall Temple Maze": "small_keys_wf(1)"
-    "Woodfall Temple Main Ledge": "event(WOODFALL_TEMPLE_MAIN_FLOWER) || event(WOODFALL_TEMPLE_MAIN_LADDER) || can_hookshot_short"
+    "Woodfall Temple Main Upper Ledge": "event(WOODFALL_TEMPLE_MAIN_FLOWER) || can_hookshot_short"
+    "Woodfall Temple Main Pots": "has(MASK_DEKU) || has_hover_boots || can_use_ice_arrows || short_hook_anywhere || (enter_woodfall_temple_water && can_swim)"
     "WARP_SONGS": "true"
   events:
     WOODFALL_TEMPLE_MAIN_FLOWER: "can_use_fire_short_range"
-    STICKS: "soul_deku_baba && can_kill_baba_sticks"
-    NUTS: "soul_deku_baba && (has(MASK_DEKU) || has_arrows || has_explosives || can_fight)"
-    BOMBS_OR_BOMBCHU: "true"
-    ARROWS: "true"
+    STICKS: "can_kill_baba_sticks"
+    NUTS: "can_kill_baba_nuts"
   locations:
-    "Woodfall Temple SF Main Pot": "true"
-    "Woodfall Temple SF Main Deku Baba": "soul_deku_baba"
-    "Woodfall Temple Pot Main Room Lower 1": "true"
-    "Woodfall Temple Pot Main Room Lower 2": "true"
-    "Woodfall Temple Pot Main Room Lower 3": "true"
-    "Woodfall Temple Pot Main Room Lower 4": "true"
-    "Woodfall Temple Pot Main Room Lower 5": "true"
-    "Woodfall Temple Pot Main Room Lower 6": "true"
+    "Woodfall Temple Center Chest": "event(WOODFALL_TEMPLE_MAIN_CHEST)"
+    "Woodfall Temple SF Main Deku Baba": "can_kill_baba_nuts || can_kill_baba_both_sticks"
     "Woodfall Temple Grass Main Room 1": "true"
     "Woodfall Temple Grass Main Room 2": "true"
     "Woodfall Temple Grass Main Room 3": "true"
 
-"Woodfall Temple Water Room":
+"Woodfall Temple Main Water Room Ledge":
   dungeon: WF
   exits:
-    "Woodfall Temple Main": "true"
-    "Woodfall Temple Map Room": "has(MASK_DEKU) || can_hookshot_short || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || (has_arrows && (has_weapon || has_mask_goron || has_hover_boots))"
-    "Woodfall Temple Water Room Upper": "(has_arrows && (has(MASK_DEKU) || has_hover_boots)) || short_hook_anywhere"
+    "Woodfall Temple Main Entrance Ledge": "has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim) || can_use_ice_arrows || has_bombs || has_mask_goron || short_hook_anywhere || (event(WOODFALL_TEMPLE_MAIN_FLOWER) && has_hover_boots)"
+    "Woodfall Temple Main Upper Ledge": "event(WOODFALL_TEMPLE_MAIN_LADDER) || short_hook_anywhere || (can_hookshot_short && (can_use_ice_arrows || has_bombs || has_mask_goron))"
+    "Woodfall Temple Main Pots": "has(MASK_DEKU) || has_hover_boots || can_use_ice_arrows || short_hook_anywhere || (enter_woodfall_temple_water && can_swim)"
+    "Woodfall Temple Water Room Lower Ledge": "true"
     "WARP_SONGS": "true"
   locations:
-    "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && event(WOODFALL_TEMPLE_MAIN_FLOWER)) || can_use_ice_arrows"
-    "Woodfall Temple SF Water Room Beehive": "has_arrows || can_use_deku_bubble || (has(MASK_GREAT_FAIRY) && (has_bombchu || has_mask_zora || can_hookshot))"
+    "Woodfall Temple Pot Main Room Lower 2": "true"
+    "Woodfall Temple Pot Main Room Lower 3": "true"
+
+"Woodfall Temple Main Pots":
+  dungeon: WF
+  exits:
+    "Woodfall Temple Main Entrance Ledge": "has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim) || can_use_ice_arrows || hookshot_anywhere"
+    "Woodfall Temple Main Upper Ledge": "short_hook_anywhere"
+    "Woodfall Temple Main Water Room Ledge": "has(MASK_DEKU) || has_hover_boots || can_use_ice_arrows || short_hook_anywhere || (enter_woodfall_temple_water && can_swim)"
+    "WARP_SONGS": "true"
+  events:
+    BOMBS_OR_BOMBCHU: "true"
+    ARROWS: "true"
+    MAGIC: "true"
+  locations:
+    "Woodfall Temple Pot Main Room Lower 1": "true"
+    "Woodfall Temple Pot Main Room Lower 4": "true"
+    "Woodfall Temple Pot Main Room Lower 5": "true"
+    "Woodfall Temple Pot Main Room Lower 6": "true"
+
+"Woodfall Temple Water Room Lower Ledge":
+  dungeon: WF
+  exits:
+    "Woodfall Temple Main Water Room Ledge": "true"
+    "Woodfall Temple Water Room Map Ledge": "has(MASK_DEKU) || can_hookshot || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || short_hook_anywhere || (has_hover_boots && (has_arrows || can_hookshot_short)) || (has_mask_goron && (has_hover_boots || can_hookshot_short)) || (enter_woodfall_temple_water && can_enter_water && is_child && (can_hookshot_short || (has_arrows && (has_weapon || has_mask_zora || has_mask_goron || has_sticks))))"
+    "Woodfall Temple Water Room Upper Ledge": "(has_arrows && (has(MASK_DEKU) || has_hover_boots)) || short_hook_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has_arrows && has(MASK_DEKU)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "WARP_SONGS": "true"
+  locations:
+    "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
+    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron))) || (has(MASK_GREAT_FAIRY) && (has_arrows || has_bombchu || can_hookshot))"
+
+"Woodfall Temple Water Room Map Ledge":
+  dungeon: WF
+  exits:
+    "Woodfall Temple Map Room": "true"
+    "Woodfall Temple Water Room Lower Ledge": "has(MASK_DEKU) || short_hook_anywhere || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_hover_boots || (can_use_nayru && can_swim) || (has_arrows && (has_mask_goron || (enter_woodfall_temple_water && can_enter_water && is_child)))"
+    "Woodfall Temple Water Room Upper Ledge": "(has_arrows && (has(MASK_DEKU) || has_hover_boots)) || short_hook_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has_arrows && has(MASK_DEKU)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "WARP_SONGS": "true"
+  locations:
+    "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
+    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron))) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
     "Woodfall Temple Grass Water Room 1": "true"
     "Woodfall Temple Grass Water Room 2": "true"
 
 "Woodfall Temple Map Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Water Room": "true"
+    "Woodfall Temple Water Room Map Ledge": "true"
     "WARP_SONGS": "true"
   locations:
-    "Woodfall Temple Map": "soul_enemy(SOUL_ENEMY_SNAPPER) && (has(MASK_DEKU) || has_explosives || has_mask_goron || can_hammer)"
+    "Woodfall Temple Map": "can_kill_snappers_flowers"
     "Woodfall Temple Grass Map Room 1": "true"
     "Woodfall Temple Grass Map Room 2": "true"
     "Woodfall Temple Grass Map Room 3": "true"
@@ -83,17 +135,17 @@
 "Woodfall Temple Maze":
   dungeon: WF
   exits:
-    "Woodfall Temple Main": "true"
+    "Woodfall Temple Main Entrance Ledge": "small_keys_wf(1)"
     "Woodfall Temple Compass Room": "has_sticks || can_use_fire_short_range"
     "Woodfall Temple Dark Room": "has_sticks || can_use_fire_short_range"
     "WARP_SONGS": "true"
   locations:
-    "Woodfall Temple SF Maze Skulltula": "soul_skulltula && (can_fight || has_weapon_range || has_explosives || deku_stick_fighting)"
+    "Woodfall Temple SF Maze Skulltula": "can_kill_skulltulas"
     "Woodfall Temple SF Maze Beehive": "has_weapon_range || has_explosives"
-    "Woodfall Temple SF Maze Bubble": "(has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot_short)) || event(WOODFALL_TEMPLE_MAIN_FLOWER) || can_use_nayru"
+    "Woodfall Temple SF Maze Bubble": "(has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot_short)) || (enter_woodfall_temple_water && can_swim_or_sink)"
     "Woodfall Temple Pot Maze 1": "true"
     "Woodfall Temple Pot Maze 2": "true"
-    "Woodfall Temple Hive Maze": "break_hive"
+    "Woodfall Temple Hive Maze": "has_weapon_range || has_explosives"
 
 "Woodfall Temple Compass Room":
   dungeon: WF
@@ -101,7 +153,7 @@
     "Woodfall Temple Maze": "true"
     "WARP_SONGS": "true"
   locations:
-    "Woodfall Temple Compass": "soul_enemy(SOUL_ENEMY_DRAGONFLY)"
+    "Woodfall Temple Compass": "can_kill_dragonflies"
     "Woodfall Temple Grass Compass Room 1": "true"
     "Woodfall Temple Grass Compass Room 2": "true"
     "Woodfall Temple Grass Compass Room 3": "true"
@@ -110,19 +162,22 @@
   dungeon: WF
   exits:
     "Woodfall Temple Maze": "has_sticks || has_arrows"
-    "Woodfall Temple Pits Room": "true"
+    "Woodfall Temple Pits Room": "has_sticks || can_use_fire_short_range"
     "WARP_SONGS": "true"
+  events:
+    STICKS: "can_kill_baba_sticks"
+    NUTS: "can_kill_baba_nuts"
   locations:
-    "Woodfall Temple Dark Chest": "soul_enemy(SOUL_ENEMY_BOE)"
+    "Woodfall Temple Dark Chest": "can_kill_boes"
 
 "Woodfall Temple Pits Room":
   dungeon: WF
   events:
     RUPEES: "true"
   exits:
-    "Woodfall Temple Main": "true"
+    "Woodfall Temple Main Entrance Ledge": "true"
     "Woodfall Temple Dark Room": "true"
-    "Woodfall Temple Main Ledge": "has(MASK_DEKU) || short_hook_anywhere"
+    "Woodfall Temple Main Upper Ledge": "has(MASK_DEKU) || short_hook_anywhere"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Grass Pits Room 01": "true"
@@ -137,33 +192,35 @@
     "Woodfall Temple Grass Pits Room 10": "true"
     "Woodfall Temple Grass Pits Room 11": "true"
 
-"Woodfall Temple Main Ledge":
+"Woodfall Temple Main Upper Ledge":
   dungeon: WF
   exits:
-    "Woodfall Temple Main": "true"
+    "Woodfall Temple Main Entrance Ledge": "has(MASK_DEKU) || short_hook_anywhere || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_hover_boots || has_bombs || has_mask_goron || (can_use_nayru && can_swim) || (event(WOODFALL_TEMPLE_MAIN_CHEST) && can_hookshot)"
     "Woodfall Temple Pits Room": "true"
-    "Woodfall Temple Pre-Boss": "has_arrows || can_use_din"
+    "Woodfall Temple Pre-Boss Main Ledge": "has_arrows || can_use_din"
     "Woodfall Temple Water Room Upper": "true"
     "WARP_SONGS": "true"
   events:
     WOODFALL_TEMPLE_MAIN_FLOWER: "has_arrows"
     WOODFALL_TEMPLE_MAIN_LADDER: "true"
+    WOODFALL_TEMPLE_MAIN_CHEST: "has(MASK_DEKU) || short_hook_anywhere || has_hover_boots"
   locations:
-    "Woodfall Temple Center Chest": "has(MASK_DEKU) || short_hook_anywhere || has_hover_boots"
     "Woodfall Temple SF Main Bubble": "true"
     "Woodfall Temple Pot Main Room Upper 1": "true"
     "Woodfall Temple Pot Main Room Upper 2": "true"
 
-"Woodfall Temple Water Room Upper":
+"Woodfall Temple Water Room Upper Ledge":
   dungeon: WF
   exits:
-    "Woodfall Temple Main Ledge": "true"
-    "Woodfall Temple Water Room": "true"
+    "Woodfall Temple Main Upper Ledge": "true"
+    "Woodfall Temple Water Room Lower Ledge": "has_bombs || has_mask_goron || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_arrows || has_hover_boots || short_hook_anywhere || can_swim || can_use_ice_arrows"
+    "Woodfall Temple Water Room Map Ledge": "has_bombs || has_mask_goron || has_hover_boots || can_use_ice_arrows || can_hookshot_short"
     "Woodfall Temple Bow Room": "true"
-    "Woodfall Temple Boss Key Room": "(has_arrows && has(MASK_DEKU)) || (short_hook_anywhere && event(WOODFALL_TEMPLE_MAIN_FLOWER)) || hookshot_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has_arrows && has(MASK_DEKU)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
     "WARP_SONGS": "true"
   locations:
-    "Woodfall Temple Water Chest": "has_hover_boots"
+    "Woodfall Temple Water Chest": "has(MASK_DEKU) || has_hover_boots || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
+    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || (has_arrows && (can_hookshot || can_use_ice_arrows || has(MASK_DEKU) || (enter_woodfall_temple_water && can_swim_or_sink) || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron))) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
     "Woodfall Temple Pot Water Room 1": "true"
     "Woodfall Temple Pot Water Room 2": "true"
     "Woodfall Temple Pot Water Room 3": "true"
@@ -172,23 +229,38 @@
 "Woodfall Temple Bow Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Water Room Upper": "can_fight || has_arrows"
+    "Woodfall Temple Water Room Upper Ledge": "can_kill_lizalfos_dinalfos"
     "WARP_SONGS": "true"
   locations:
-    "Woodfall Temple Bow": "soul_lizalfos_dinolfos && (can_fight || has_arrows)"
+    "Woodfall Temple Bow": "can_kill_lizalfos_dinalfos"
+
+"Woodfall Temple Water Room Boss Key Ledge":
+  dungeon: WF
+  exits:
+    "Woodfall Temple Water Room Lower Ledge": "has_bombs || has_mask_goron || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_hover_boots || hookshot_anywhere || can_use_ice_arrows || (can_use_nayru && can_swim)"
+    "Woodfall Temple Water Room Map Ledge": "has_bombs || has_mask_goron || event(WOODFALL_TEMPLE_MAIN_FLOWER) || can_hookshot || has_hover_boots || can_use_ice_arrows"
+    "Woodfall Temple Water Room Upper Ledge": "has(MASK_DEKU) || hookshot_anywhere"
+    "Woodfall Temple Boss Key Room": "true"
+    "WARP_SONGS": "true"
+  locations:
+    "Woodfall Temple Water Chest": "has(MASK_DEKU) || has_hover_boots || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows || short_hook_anywhere"
+    "Woodfall Temple SF Water Room Beehive": "can_use_deku_bubble || has_arrows || has_bombs || (has(MASK_GREAT_FAIRY) && (has_mask_zora || can_hookshot_short))"
 
 "Woodfall Temple Boss Key Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Boss Key Room Cage": "soul_enemy(SOUL_ENEMY_GEKKO) && has_arrows && (has(MASK_DEKU) || has_mask_goron || can_hammer || has_explosives)"
+    "Woodfall Temple Water Room Boss Key Ledge": "event(WOODFALL_TEMPLE_GEKKO)"
+    "Woodfall Temple Boss Key Room Cage": "event(WOODFALL_TEMPLE_GEKKO)"
     "WARP_SONGS": "true"
+  events:
+    WOODFALL_TEMPLE_GEKKO: "can_kill_gekko_wft"
+    FROG_2: "event(WOODFALL_TEMPLE_GEKKO) && has(MASK_DON_GERO)"
 
 "Woodfall Temple Boss Key Room Cage":
   dungeon: WF
   exits:
+    "Woodfall Temple Boss Key Room": "event(WOODFALL_TEMPLE_GEKKO)"
     "WARP_SONGS": "true"
-  events:
-    FROG_2: "has(MASK_DON_GERO)"
   locations:
     "Woodfall Temple Boss Key Chest": "true"
     "Woodfall Temple Pot Miniboss Room 1": "true"
@@ -196,36 +268,52 @@
     "Woodfall Temple Pot Miniboss Room 3": "true"
     "Woodfall Temple Pot Miniboss Room 4": "true"
 
-"Woodfall Temple Pre-Boss":
+"Woodfall Temple Pre-Boss Main Ledge":
   dungeon: WF
   exits:
-    "Woodfall Temple Pre-Boss Ledge": "can_hookshot || has(MASK_DEKU) || short_hook_anywhere"
+    "Woodfall Temple Main Upper Ledge": "true"
+    "Woodfall Temple Pre-Boss Far Ledge": "has(MASK_DEKU) || hookshot_anywhere || (can_hookshot && (can_swim || has_hover_boots || can_use_ice_arrows)) || (has_arrows && short_hook_anywhere)"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple SF Pre-Boss Bottom Right": "true"
-    "Woodfall Temple SF Pre-Boss Left": "has(MASK_DEKU) || has(MASK_GREAT_FAIRY) || short_hook_anywhere"
+    "Woodfall Temple SF Pre-Boss Left": "has(MASK_DEKU) || short_hook_anywhere || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
     "Woodfall Temple SF Pre-Boss Top Right": "true"
-    "Woodfall Temple SF Pre-Boss Pillar": "has(MASK_DEKU) || has(MASK_GREAT_FAIRY) || short_hook_anywhere"
+    "Woodfall Temple SF Pre-Boss Pillar": "short_hook_anywhere || has(MASK_DEKU) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
     "Woodfall Temple Grass Pre-Boss 1": "true"
     "Woodfall Temple Grass Pre-Boss 2": "true"
     "Woodfall Temple Grass Pre-Boss 3": "true"
     "Woodfall Temple Grass Pre-Boss 4": "true"
     "Woodfall Temple Grass Pre-Boss 5": "true"
-    "Woodfall Temple Rupee Lower 1": "has(MASK_DEKU) || is_tall || can_goron_bomb_jump || short_hook_anywhere"
-    "Woodfall Temple Rupee Lower 2": "has(MASK_DEKU) || is_tall || can_goron_bomb_jump || short_hook_anywhere"
-    "Woodfall Temple Rupee Lower 3": "has(MASK_DEKU) || is_tall || can_goron_bomb_jump || short_hook_anywhere"
-    "Woodfall Temple Rupee Lower 4": "has(MASK_DEKU) || is_tall || can_goron_bomb_jump || short_hook_anywhere"
+    "Woodfall Temple Rupee Lower 1": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && (can_hookshot || is_adult))"
+    "Woodfall Temple Rupee Lower 2": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && (can_hookshot || is_adult))"
+    "Woodfall Temple Rupee Lower 3": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && is_adult)"
+    "Woodfall Temple Rupee Lower 4": "has(MASK_DEKU) || has_mask_zora || can_goron_bomb_jump || short_hook_anywhere || ((has_hover_boots || can_swim || can_use_ice_arrows) && is_adult)"
+    "Woodfall Temple Rupee Upper Right": "has(MASK_DEKU)"
 
-"Woodfall Temple Pre-Boss Ledge":
+"Woodfall Temple Pre-Boss Far Ledge":
   dungeon: WF
   exits:
+    "Woodfall Temple Pre-Boss Main Ledge": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
     "Woodfall Temple Boss Access": "boss_key(BOSS_KEY_WF)"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Pot Pre-Boss 1": "true"
     "Woodfall Temple Pot Pre-Boss 2": "true"
     "Woodfall Temple Rupee Upper Left": "has_mask_zora || short_hook_anywhere || (can_use_ice_arrows && trick(MM_WFT_RUPEES_ICE)) || has_hover_boots"
-    "Woodfall Temple Rupee Upper Right": "has(MASK_DEKU) || has_mask_zora || hookshot_anywhere || (can_use_ice_arrows && trick(MM_WFT_RUPEES_ICE)) || has_hover_boots"
+    "Woodfall Temple Rupee Upper Right": "has_mask_zora || short_hook_anywhere || (can_use_ice_arrows && trick(MM_WFT_RUPEES_ICE)) || has_hover_boots"
+    "Woodfall Temple SF Pre-Boss Bottom Right": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
+    "Woodfall Temple SF Pre-Boss Left": "has(MASK_DEKU) || short_hook_anywhere || (has(MASK_GREAT_FAIRY) && has_arrows)"
+    "Woodfall Temple SF Pre-Boss Top Right": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall) || (has(MASK_GREAT_FAIRY) && has_arrows)"
+    "Woodfall Temple SF Pre-Boss Pillar": "short_hook_anywhere || has(MASK_DEKU) || (has(MASK_GREAT_FAIRY) && (has_arrows || can_hookshot))"
+    "Woodfall Temple Grass Pre-Boss 1": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+    "Woodfall Temple Grass Pre-Boss 2": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+    "Woodfall Temple Grass Pre-Boss 3": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+    "Woodfall Temple Grass Pre-Boss 4": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+    "Woodfall Temple Grass Pre-Boss 5": "short_hook_anywhere || has(MASK_DEKU) || (can_use_ice_arrows && is_tall)"
+    "Woodfall Temple Rupee Lower 1": "true"
+    "Woodfall Temple Rupee Lower 2": "true"
+    "Woodfall Temple Rupee Lower 3": "true"
+    "Woodfall Temple Rupee Lower 4": "true"
 
 "Woodfall Temple Princess Jail":
   dungeon: WF

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -229,7 +229,7 @@
 "Woodfall Temple Bow Room":
   dungeon: WF
   exits:
-    "Woodfall Temple Water Room Upper Ledge": "can_kill_lizalfos_dinalfos"
+    "Woodfall Temple Water Room Upper Ledge": "can_kill_lizalfos_dinolfos"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Bow": "can_kill_lizalfos_dinalfos"


### PR DESCRIPTION
This pull request restructures the logic layout of Woodfall Temple to better suit it for Bronze Scale implementation as well as future-proofing it for door and action rando. Most of the rooms have seen significant changes and additions. If you see anything that might seem a little suspect to be base logic, do point it out so that a discussion can be had on it.

One thing to note is that going from Main Water Room Ledge to Main Entrance Ledge via bombs or goron is currently in the logic, but you are also able to light the flower's torch from there (and the pots). Without lighting the torch in the logic from there, this won't break any seeds (and would only be able to in door rando), but if we would want to include both at some point, the flower torch may need a similar flag system to the region states and planned SHT pillar.