### PR TITLE
Fix wrong double quote character in macros_mm.yml

### DIFF
--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -372,7 +372,7 @@
 "can_kill_snappers_any": "soul_enemy(SOUL_ENEMY_SNAPPER) && (has_explosives || has_mask_goron || can_hammer)"
 "can_kill_warts": "soul_enemy(SOUL_ENEMY_WART) && has_weapon && (has_mask_zora || has_explosives || has_arrows || can_hookshot_short || can_use_din || has_nuts)" #the () is for ways to clear the bubbles
 "can_kill_keeta": "soul_enemy(SOUL_ENEMY_CAPTAIN_KEETA) && has_arrows && can_fight"
-“can_fight_pirates”: "soul_thief_fighter && (can_fight || has_arrows || deku_stick_fighting)"
+"can_fight_pirates": "soul_thief_fighter && (can_fight || has_arrows || deku_stick_fighting)"
 "can_kill_aliens": "has_arrows" # This is specifically for enemy drops. While Din's can kill, the actual aliens check does not allow for Din's to be logical so sticking to the same logic. No soul currently.
 #"can_kill_invisible_enemies": "can_use_lens" #Enemizer or Actorizer might make this macro relevant for switching enemies.
 


### PR DESCRIPTION
While working on AP-OOTMM, I pulled a new version of the project and had my custom converter throw a fit because there was a sneaky `“` character in here by mistake rather than the `"` double quote character

It displays as "\u201ccan_fight_pirates\u201d" when converted.

VsCode caught it:
The character U+201d `”` is not a basic ASCII character
