### PR TITLE
chore: Add Spacing Between OoT MQ Dungeons' Regions

### DIFF
--- a/data/world/oot/dungeons_mq/bottom_of_the_well_mq.yml
+++ b/data/world/oot/dungeons_mq/bottom_of_the_well_mq.yml
@@ -4,23 +4,28 @@
     "GLOBAL": "true"
     "Kakariko Well": "true"
     "Bottom of the Well Entrance": "true"
+
 "Bottom of the Well Entrance":
   dungeon: BotW
   exits:
     "Bottom of the Well": "true"
     "Bottom of the Well Main": "is_child"
+
 "Bottom of the Well Wallmaster Main":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Bottom of the Well Wallmaster Basement":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Bottom of the Well Wallmaster Pit":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Bottom of the Well Main":
   dungeon: BotW
   exits:
@@ -47,6 +52,7 @@
     "MQ Bottom of the Well Wonder Item Main Room Right 2": "can_use_slingshot"
     "MQ Bottom of the Well Wonder Item Main Room Right 3": "can_use_slingshot"
     "MQ Bottom of the Well Wonder Item Main Room Right 4": "can_use_slingshot"
+
 "Bottom of the Well Main Room Center Switch Corner":
   dungeon: BotW
   exits:
@@ -55,6 +61,7 @@
     "Bottom of the Well Basement": "true"
   events:
     BOTW_CENTER_WEST_TORCH: "true"
+
 "Bottom of the Well Main Room Center":
   dungeon: BotW
   exits:
@@ -72,6 +79,7 @@
     "MQ Bottom of the Well Pot Lobby Cage 2": "true"
     "MQ Bottom of the Well Pot Lobby Cage 3": "true"
     "MQ Bottom of the Well Lobby Cage Big Fairy": "can_play_sun"
+
 "Bottom of the Well Basement":
   dungeon: BotW
   exits:
@@ -85,12 +93,14 @@
     "MQ Bottom of the Well Heart Basement 1": "true"
     "MQ Bottom of the Well Heart Basement 2": "true"
     "MQ Bottom of the Well Heart Basement 3": "true"
+
 "Bottom of the Well West Center Room":
   dungeon: BotW
   exits:
     "Bottom of the Well Main Room Center": "true"
   locations:
     "MQ Bottom of the Well GS West Middle Room": "gs && can_damage_skull"
+
 "Bottom of the Well East Center Room":
   dungeon: BotW
   exits:
@@ -104,6 +114,7 @@
     "MQ Bottom of the Well Wonder Item Side Room 2": "can_use_slingshot"
     "MQ Bottom of the Well Wonder Item Side Room 3": "can_use_slingshot"
     "MQ Bottom of the Well Wonder Item Side Room 4": "can_use_slingshot"
+
 "Bottom of the Well Basement Switch Ledge":
   dungeon: BotW
   exits:
@@ -111,6 +122,7 @@
     "Bottom of the Well Main Room Center": "event(BOTW_MQ_GATE_FROM_SWITCH) && climb_anywhere && hookshot_anywhere"
   events:
     BOTW_MQ_REDEAD_CHEST: "true"
+
 "Bottom of the Well Coffin Room":
   dungeon: BotW
   exits:
@@ -119,11 +131,13 @@
     "MQ Bottom of the Well GS Coffin Room": "gs && can_damage_skull"
     "MQ Bottom of the Well Heart Coffin 1": "has_fire_or_sticks"
     "MQ Bottom of the Well Heart Coffin 2": "has_fire_or_sticks"
+
 "Bottom of the Well Before Dead Hand":
   dungeon: BotW
   exits:
     "Bottom of the Well Main": "event(BOTW_MQ_DRAIN_WATER) && is_child"
     "Bottom of the Well Dead Hand Room": "true"
+
 "Bottom of the Well Dead Hand Room":
   dungeon: BotW
   exits:
@@ -135,17 +149,20 @@
     "MQ Bottom of the Well Grass Dead-Hand 2": "can_cut_grass"
     "MQ Bottom of the Well Grass Dead-Hand 3": "can_cut_grass"
     "MQ Bottom of the Well Grass Dead-Hand 4": "can_cut_grass"
+
 "Bottom of the Well Main Side Room Before Pit":
   dungeon: BotW
   exits:
     "Bottom of the Well Main": "is_child"
     "Bottom of the Well Pit Before Cage": "can_hit_triggers_distance || can_boomerang || has_explosives || can_hookshot"
+
 "Bottom of the Well Pit Before Cage":
   dungeon: BotW
   exits:
     "Bottom of the Well Main Side Room Before Pit": "true"
     "Bottom of the Well Cage": "small_keys_botw(2)"
     "Bottom of the Well Wallmaster Pit": "soul_wallmaster"
+
 "Bottom of the Well Cage":
   dungeon: BotW
   exits:

--- a/data/world/oot/dungeons_mq/deku_tree_mq.yml
+++ b/data/world/oot/dungeons_mq/deku_tree_mq.yml
@@ -4,6 +4,7 @@
     "GLOBAL": "true"
     "Kokiri Forest Near Deku Tree": "true"
     "MQ Deku Tree Lobby": "true"
+
 "MQ Deku Tree Lobby":
   dungeon: DT
   exits:
@@ -19,6 +20,7 @@
     "MQ Deku Tree Grass Entrance Lower 3": "can_cut_grass"
     "MQ Deku Tree Grass Entrance Lower 4": "can_cut_grass"
     "MQ Deku Tree Grass Entrance Lower 5": "can_cut_grass"
+
 "MQ Deku Tree 2nd Floor":
   dungeon: DT
   exits:
@@ -32,16 +34,19 @@
     "MQ Deku Tree Grass Entrance Upper 1": "can_cut_grass"
     "MQ Deku Tree Grass Entrance Upper 2": "can_cut_grass"
     "MQ Deku Tree Main Room 2nd Floor Crate": "true"
+
 "MQ Deku Tree Room Before Compass Room Entry Door":
   dungeon: DT
   exits:
     "MQ Deku Tree 2nd Floor": "true"
     "MQ Deku Tree Room Before Compass Room Door to 2nd Floor": "true"
+
 "MQ Deku Tree Room Before Compass Room Door to 2nd Floor":
   dungeon: DT
   exits:
     "MQ Deku Tree Room Before Compass Room Entry Door": "true"
     "MQ Deku Tree Room Before Compass Room": "true"
+
 "MQ Deku Tree Room Before Compass Room":
   dungeon: DT
   exits:
@@ -60,21 +65,25 @@
     "MQ Deku Tree Grass Room Before Compass 5": "can_cut_grass"
     "MQ Deku Tree Grass Room Before Compass 6": "can_cut_grass"
     "MQ Deku Tree Grass Room Before Compass 7": "can_cut_grass"
+
 "MQ Deku Tree Compass Room Entry Door":
   dungeon: DT
   exits:
     "MQ Deku Tree Room Before Compass Room": "true"
     "MQ Deku Tree Compass Room Exit Door": "event(DEKU_MQ_BEFORE_COMPASS_EYE_SWITCH)"
+
 "MQ Deku Tree Compass Room Exit Door":
   dungeon: DT
   exits:
     "MQ Deku Tree Compass Room Entry Door": "true"
     "MQ Deku Tree MQ Compass Room Entrance": "true"
+
 "MQ Deku Tree MQ Compass Room Entrance":
   dungeon: DT
   exits:
     "MQ Deku Tree Compass Room Exit Door": "true"
     "MQ Deku Tree MQ Compass Room Chest Side": "true"
+
 "MQ Deku Tree MQ Compass Room Chest Side":
   dungeon: DT
   exits:
@@ -86,6 +95,7 @@
     "MQ Deku Tree Grass Compass Room 2": "can_cut_grass"
     "MQ Deku Tree Grass Compass Room 3": "can_cut_grass"
     "MQ Deku Tree Grass Compass Room 4": "can_cut_grass"
+
 "MQ Deku Tree MQ Compass Room Chest Side Alcove":
   dungeon: DT
   exits:
@@ -93,6 +103,7 @@
   locations:
     "MQ Deku Tree GS Compass Room": "gs && can_collect_distance"
     "MQ Deku Tree Heart Compass Room": "true"
+
 "MQ Deku Tree 3rd Floor":
   dungeon: DT
   exits:
@@ -102,16 +113,19 @@
     "MQ Deku Tree Slingshot Room Entry Door": "has_fire || event(DEKU_MQ_MAIN_TORCH)"
   events:
     DEKU_MQ_MAIN_TORCH: "true"
+
 "MQ Deku Tree Slingshot Room Entry Door":
   dungeon: DT
   exits:
     "MQ Deku Tree 3rd Floor": "true"
     "MQ Deku Tree Slingshot Room Exit Door": "true"
+
 "MQ Deku Tree Slingshot Room Exit Door":
   dungeon: DT
   exits:
     "MQ Deku Tree Slingshot Room Entry Door": "event(DEKU_MQ_SLINGSHOT_ENEMIES)"
     "MQ Deku Tree MQ Slingshot Room": "true"
+
 "MQ Deku Tree MQ Slingshot Room":
   dungeon: DT
   exits:
@@ -129,6 +143,7 @@
     "MQ Deku Tree Grass Slingshot Room Back 2": "can_cut_grass"
     "MQ Deku Tree Slingshot Room Large Crate 1": "true"
     "MQ Deku Tree Slingshot Room Large Crate 2": "true"
+
 "MQ Deku Tree Basement":
   dungeon: DT
   exits:
@@ -144,16 +159,19 @@
     "MQ Deku Tree Grass Basement Lower 2": "can_cut_grass"
     "MQ Deku Tree Grass Basement Lower 3": "can_cut_grass"
     "MQ Deku Tree Grass Basement Lower 4": "can_cut_grass"
+
 "MQ Deku Tree Room Before Water Room Entry Door":
   dungeon: DT
   exits:
     "MQ Deku Tree Basement": "true"
     "MQ Deku Tree Room Before Water Room Door to Basement": "event(DEKU_MQ_BASEMENT_EYE_SWITCH)"
+
 "MQ Deku Tree Room Before Water Room Door to Basement":
   dungeon: DT
   exits:
     "MQ Deku Tree Room Before Water Room Entry Door": "event(DEKU_MQ_ROOM_BEFORE_WATER_CLEAR)"
     "MQ Deku Tree Room Before Water Room": "true"
+
 "MQ Deku Tree Room Before Water Room":
   dungeon: DT
   exits:
@@ -167,16 +185,19 @@
     "MQ Deku Tree Grass Room Before Spike 2": "can_cut_grass"
     "MQ Deku Tree Grass Room Before Spike 3": "can_cut_grass"
     "MQ Deku Tree Grass Room Before Spike 4": "can_cut_grass"
+
 "MQ Deku Tree Room Before Water Room Door to Water Room":
   dungeon: DT
   exits:
     "MQ Deku Tree Room Before Water Room": "true"
     "MQ Deku Tree Water Room Door to Room Before Water Room": "event(DEKU_MQ_WATER_PATH_TORCH1)"
+
 "MQ Deku Tree Water Room Door to Room Before Water Room":
   dungeon: DT
   exits:
     "MQ Deku Tree Room Before Water Room Door to Water Room": "true"
     "MQ Deku Tree Water Room Front": "true"
+
 "MQ Deku Tree Water Room Front":
   dungeon: DT
   exits:
@@ -189,6 +210,7 @@
     "MQ Deku Tree Grass Spike Room Front 1": "can_cut_grass"
     "MQ Deku Tree Grass Spike Room Front 2": "can_cut_grass"
     "MQ Deku Tree Grass Spike Room Front 3": "can_cut_grass"
+
 "MQ Deku Tree Water Room Back":
   dungeon: DT
   exits:
@@ -200,16 +222,19 @@
     "MQ Deku Tree After Water Platform Chest": "can_play_time"
     "MQ Deku Tree Grass Spike Room Back 1": "can_cut_grass"
     "MQ Deku Tree Grass Spike Room Back 2": "can_cut_grass"
+
 "MQ Deku Tree Water Room Door to Room After Water Room":
   dungeon: DT
   exits:
     "MQ Deku Tree Water Room Back": "true"
     "MQ Deku Tree Room After Water Room Door to Water Room": "event(MQ_DEKU_WATER_TORCHES)"
+
 "MQ Deku Tree Room After Water Room Door to Water Room":
   dungeon: DT
   exits:
     "MQ Deku Tree Water Room Door to Room After Water Room": "event(DEKU_MQ_ROOM_AFTER_WATER_CLEAR)"
     "MQ Deku Tree Room After Water Room": "true"
+
 "MQ Deku Tree Room After Water Room":
   dungeon: DT
   exits:
@@ -220,16 +245,19 @@
   locations:
     "MQ Deku Tree Grass Larvae Room 1": "can_cut_grass"
     "MQ Deku Tree Grass Larvae Room 2": "can_cut_grass"
+
 "MQ Deku Tree Room After Water Room Door to Gravestone Room":
   dungeon: DT
   exits:
     "MQ Deku Tree Room After Water Room": "true"
     "MQ Deku Tree Gravestone Room Door to Room After Water Room": "event(DEKU_MQ_ROOM_AFTER_WATER_CLEAR)"
+
 "MQ Deku Tree Gravestone Room Door to Room After Water Room":
   dungeon: DT
   exits:
     "MQ Deku Tree Room After Water Room Door to Gravestone Room": "true"
     "MQ Deku Tree MQ Grave Room": "true"
+
 "MQ Deku Tree MQ Grave Room":
   dungeon: DT
   exits:
@@ -251,16 +279,19 @@
     "MQ Deku Tree Wonder Item 2": "can_use_sword_or_sticks"
     "MQ Deku Tree Wonder Item 3": "can_use_sword_or_sticks"
     "MQ Deku Tree Wonder Item 4": "can_use_sword_or_sticks"
+
 "MQ Deku Tree Back Side Room Entry Door":
   dungeon: DT
   exits:
     "MQ Deku Tree MQ Grave Room": "true"
     "MQ Deku Tree Back Side Room Exit Door": "true"
+
 "MQ Deku Tree Back Side Room Exit Door":
   dungeon: DT
   exits:
     "MQ Deku Tree Back Side Room Entry Door": "true"
     "MQ Deku Tree Back Side Room": "true"
+
 "MQ Deku Tree Back Side Room":
   dungeon: DT
   exits:
@@ -273,6 +304,7 @@
     "MQ Deku Tree Grass Back Room 1": "can_cut_grass"
     "MQ Deku Tree Grass Back Room 2": "can_cut_grass"
     "MQ Deku Tree Grass Back Room 3": "can_cut_grass"
+
 "MQ Deku Tree Basement Ledge":
   dungeon: DT
   exits:
@@ -288,6 +320,7 @@
     "MQ Deku Tree Grass Basement Upper 1": "can_cut_grass"
     "MQ Deku Tree Grass Basement Upper 2": "can_cut_grass"
     "MQ Deku Tree Grass Basement Upper 3": "can_cut_grass"
+
 "MQ Deku Tree Pre-Boss Room Water Section":
   dungeon: DT
   exits:
@@ -297,6 +330,7 @@
     "MQ Deku Tree Heart Before Boss 1": "can_swim_or_sink"
     "MQ Deku Tree Heart Before Boss 2": "can_swim_or_sink"
     "MQ Deku Tree Heart Before Boss 3": "can_swim_or_sink"
+
 "Deku Tree Before Boss":
   dungeon: DT
   exits:
@@ -309,6 +343,7 @@
     "MQ Deku Tree Grass Room Before Boss 1": "can_cut_grass"
     "MQ Deku Tree Grass Room Before Boss 2": "can_cut_grass"
     "MQ Deku Tree Grass Room Before Boss 3": "can_cut_grass"
+
 #The below is for later on. Keeping here as a backup.
 #"MQ Deku Tree MQ Compass Room Entrance":
   #dungeon: DT

--- a/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
+++ b/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
@@ -4,11 +4,13 @@
     "GLOBAL": "true"
     "Death Mountain": "true"
     "Dodongo Cavern Entrance": "true"
+
 "Dodongo Cavern Entrance":
   dungeon: DC
   exits:
     "Dodongo Cavern": "true"
     "Dodongo Cavern Main Room Lower": "has_bombflowers || can_hammer || has_blue_fire_arrows_mudwall"
+
 "Dodongo Cavern Main Room Lower":
   dungeon: DC
   exits:
@@ -28,6 +30,7 @@
     "MQ Dodongo Cavern Lobby Scrub Back": "business_scrub(0x1d)"
   gossip:
     "Dodongo Cavern Gossip": "has_bombflowers || can_hammer || has_blue_fire_arrows_mudwall"
+
 "Dodongo Cavern Main Room Upper Skull Side":
   dungeon: DC
   exits:
@@ -38,6 +41,7 @@
     MQ_DC_OPEN_SKULL: "has_explosives"
     MQ_DC_STAIRCASE_SWITCH: "true"
     DC_MQ_SHORTCUT: "has_explosives_or_hammer || can_use_din"
+
 "Dodongo Cavern Staircase Room Lower":
   dungeon: DC
   exits:
@@ -56,12 +60,14 @@
     "MQ Dodongo Cavern Pot Stairs 4": "true"
     "MQ Dodongo Cavern Staircase Room Lower Large Crate 1": "true"
     "MQ Dodongo Cavern Staircase Room Lower Large Crate 2": "true"
+
 "Dodongo Cavern MQ Song of Time Block Room":
   dungeon: DC
   exits:
     "Dodongo Cavern Staircase Room Lower": "true"
   locations:
     "MQ Dodongo Cavern GS Time Blocks": "gs && can_play_time && can_damage_skull"
+
 "Dodongo Cavern Staircase Room Upper":
   dungeon: DC
   exits:
@@ -76,6 +82,7 @@
     "MQ Dodongo Cavern Staircase Room Upper Large Crate 2": "true"
     "MQ Dodongo Cavern Staircase Room Upper Large Crate 3": "true"
     "MQ Dodongo Cavern Staircase Room Upper Large Crate 4": "true"
+
 "Dodongo Cavern Room After Upper Staircase":
   dungeon: DC
   exits:
@@ -89,6 +96,7 @@
     "MQ Dodongo Cavern Grass Compass Room 2": "can_cut_grass"
     "MQ Dodongo Cavern Grass Compass Room 3": "can_cut_grass"
     "MQ Dodongo Cavern Grass Compass Room 4": "can_cut_grass"
+
 "Dodongo Cavern Main Room Upper Entrance Side":
   dungeon: DC
   exits:
@@ -96,6 +104,7 @@
     "Dodongo Cavern Room After Upper Staircase": "true"
     "Dodongo Cavern Main Room Upper Skull Side": "longshot_anywhere"
     "Dodongo Cavern Vanilla Bomb Bag Room Lower": "true"
+
 "Dodongo Cavern Vanilla Bomb Bag Room Lower":
   dungeon: DC
   exits:
@@ -109,6 +118,7 @@
     "MQ Dodongo Cavern Heart Vanilla Bomb Bag Room": "true"
     # Fails to load
     "MQ Dodongo Cavern Grass Vanilla Bomb Bag Room": "can_cut_grass"
+
 "Dodongo Cavern Vanilla Bomb Bag Room Upper":
   dungeon: DC
   exits:
@@ -121,6 +131,7 @@
     "MQ Dodongo Cavern Upper Ledge Chest": "true"
     "MQ Dodongo Cavern Pot Vanilla Bomb Bag Room 1": "true"
     "MQ Dodongo Cavern Pot Vanilla Bomb Bag Room 2": "true"
+
 "Dodongo Cavern MQ Larvae Room":
   dungeon: DC
   exits:
@@ -136,6 +147,7 @@
     "MQ Dodongo Cavern Larve Room Large Crate 4": "true"
     "MQ Dodongo Cavern Larve Room Large Crate 5": "true"
     "MQ Dodongo Cavern Larve Room Large Crate 6": "true"
+
 "Dodongo Cavern Room Before Upper Lizalfos":
   dungeon: DC
   exits:
@@ -148,6 +160,7 @@
     "MQ Dodongo Cavern Pot Before Miniboss 2": "true"
     # Fails to load
     "MQ Dodongo Cavern Grass Room Before Miniboss": "can_cut_grass"
+
 "Dodongo Cavern Room After Upper Lizalfos":
   dungeon: DC
   exits:
@@ -158,6 +171,7 @@
     "MQ Dodongo Cavern Pot After Miniboss 2": "true"
     "MQ Dodongo Cavern Room After Upper Lizalfos Large Crate 1": "true"
     "MQ Dodongo Cavern Room After Upper Lizalfos Large Crate 2": "true"
+
 "Dodongo Cavern Upper Lizalfos":
   dungeon: DC
   exits:
@@ -174,6 +188,7 @@
     "MQ Dodongo Cavern Pot Miniboss 3": "true"
     "MQ Dodongo Cavern Pot Miniboss 4": "true"
     "MQ Dodongo Cavern Heart Lizalfos Room": "has_explosives_or_hammer || hookshot_anywhere || climb_anywhere" #In Lower section, putting it here too because of the lizalfos event won't trigger when starting in opposite section.
+
 "Dodongo Cavern Lower Tunnel":
   dungeon: DC
   exits:
@@ -187,17 +202,20 @@
     "MQ Dodongo Cavern Pot East Corridor 2": "true"
     "MQ Dodongo Cavern Pot East Corridor 3": "true"
     "MQ Dodongo Cavern Pot East Corridor 4": "true"
+
 "Dodongo Cavern Lower Tunnel Side Room":
   dungeon: DC
   exits:
     "Dodongo Cavern Lower Tunnel": "true"
   locations:
     "MQ Dodongo Cavern Tunnel Side Scrub": "business_scrub(0x1e)"
+
 "Dodongo Cavern Corridor Before Lower Lizalfos":
   dungeon: DC
   exits:
     "Dodongo Cavern Lower Lizalfos": "true"
     "Dodongo Cavern Lower Tunnel": "true"
+
 "Dodongo Cavern Lower Lizalfos":
   dungeon: DC
   exits:
@@ -214,6 +232,7 @@
     "MQ Dodongo Cavern Pot Miniboss 2": "climb_anywhere || longshot_anywhere" #In Upper section, putting it here too because of the lizalfos event won't trigger when starting in opposite section.
     "MQ Dodongo Cavern Pot Miniboss 3": "climb_anywhere || longshot_anywhere" #In Upper section, putting it here too because of the lizalfos event won't trigger when starting in opposite section.
     "MQ Dodongo Cavern Pot Miniboss 4": "climb_anywhere || longshot_anywhere" #In Upper section, putting it here too because of the lizalfos event won't trigger when starting in opposite section.
+
 "Dodongo Cavern Poe Room":
   dungeon: DC
   exits:
@@ -235,6 +254,7 @@
     "MQ Dodongo Cavern Poe Room Large Crate 6": "true"
     "MQ Dodongo Cavern Poe Room Large Crate 7": "true"
     "MQ Dodongo Cavern Poe Room Large Crate 8": "true"
+
 "Dodongo Cavern MQ Poe Room Side Room":
   dungeon: DC
   exits:
@@ -243,6 +263,7 @@
     "MQ Dodongo Cavern GS Poe Room Side": "gs && can_collect_distance"
     "MQ Dodongo Cavern Grass Green Corridor Side Room 1": "can_cut_grass"
     "MQ Dodongo Cavern Grass Green Corridor Side Room 2": "can_cut_grass"
+
 "Dodongo Cavern Bomb Bag Ledge":
   dungeon: DC
   exits:
@@ -250,11 +271,13 @@
     "Dodongo Cavern Main Room Lower": "true"
   locations:
     "MQ Dodongo Cavern Bomb Bag Chest": "true"
+
 "Dodongo Cavern Main Room Inside Skull":
   dungeon: DC
   exits:
     "Dodongo Cavern Main Room Lower": "event(MQ_DC_OPEN_SKULL)"
     "Dodongo Cavern Pre-Boss Lobby": "true"
+
 "Dodongo Cavern Pre-Boss Lobby":
   dungeon: DC
   exits:
@@ -265,6 +288,7 @@
   locations:
     "MQ Dodongo Cavern Pot Before Boss 1": "true"
     "MQ Dodongo Cavern Pot Before Boss 2": "true"
+
 "Dodongo Cavern Boss Loop Start":
   dungeon: DC
   exits:
@@ -275,6 +299,7 @@
   locations:
     "MQ Dodongo Cavern Pot Before Boss Loop 1": "true"
     "MQ Dodongo Cavern Pot Before Boss Loop 2": "true"
+
 "Dodongo Cavern Boss Loop After Fire Wall":
   dungeon: DC
   exits:
@@ -286,6 +311,7 @@
   locations:
     "MQ Dodongo Cavern GS Near Boss": "gs && can_damage_skull"
     "MQ Dodongo Cavern Grass Boss Loop": "can_cut_grass"
+
 "Dodongo Cavern Boss Loop Side Room":
   dungeon: DC
   exits:
@@ -295,6 +321,7 @@
     "MQ Dodongo Cavern Pot Before Boss Loop Side Room 1": "true"
     "MQ Dodongo Cavern Pot Before Boss Loop Side Room 2": "true"
     "MQ Dodongo Cavern Grass Boss Loop Side Room": "can_cut_grass"
+
 "Dodongo Cavern Boss Loop After Armos Wall":
   dungeon: DC
   exits:
@@ -303,6 +330,7 @@
   locations:
     "MQ Dodongo Cavern Pot Before Boss Loop 3": "true"
     "MQ Dodongo Cavern Pot Before Boss Loop 4": "true"
+
 "Dodongo Cavern Boss Loop Ending Ledge":
   dungeon: DC
   exits:

--- a/data/world/oot/dungeons_mq/fire_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/fire_temple_mq.yml
@@ -4,11 +4,13 @@
     "GLOBAL": "true"
     "Death Mountain Crater Near Temple": "true"
     "Fire Temple Entrance": "true"
+
 "Fire Temple Entrance":
   dungeon: Fire
   exits:
     "Fire Temple": "true"
     "Fire Temple Lower Lobby": "true"
+
 "Fire Temple Lower Lobby":
   dungeon: Fire
   exits:
@@ -19,6 +21,7 @@
   locations:
     "MQ Fire Temple Pot Entrance 1": "true"
     "MQ Fire Temple Pot Entrance 2": "true"
+
 "Fire Temple Hammer Loop Goron Cell Like Like Side":
   dungeon: Fire
   exits:
@@ -29,12 +32,14 @@
   locations:
     "MQ Fire Temple Early Lower Left Chest": "event(FIRE_MQ_1ST_GORON_LIKELIKE)"
     "MQ Fire Temple Map Chest": "event(FIRE_MQ_MAP_CHEST_HAMMER_SWITCH)"
+
 "Fire Temple Upper Lobby":
   dungeon: Fire
   exits:
     "Fire Temple Lower Lobby": "true"
     "Fire Temple Pre-Boss Room Entrance Side": "has_fire"
     "Fire Temple 1F Lava Bridge Room Main": "can_hammer"
+
 "Fire Temple Pre-Boss Room Entrance Side":
   dungeon: Fire
   exits:
@@ -44,6 +49,7 @@
     "Fire Temple Pre-Boss Room Tall Ledges Corner": "has_tunic_goron && (climb_anywhere || can_hookshot || has_hover_boots)"
   #events:
     # FIRE_MQ_PRE_BOSS_TORCHES: "has_tunic_goron && has_fire && can_use_bow" #TODO: Trick with shotting the torch through the crate
+
 "Fire Temple Pre-Boss Room Cell Corner":
   dungeon: Fire
   exits:
@@ -53,6 +59,7 @@
     "MQ Fire Temple Pre-Boss Chest": "event(FIRE_MQ_PRE_BOSS_TORCHES)"
     "MQ Fire Temple Pre-Boss Room Near Cage Large Crate 1": "has_tunic_goron"
     "MQ Fire Temple Pre-Boss Room Near Cage Large Crate 2": "has_tunic_goron"
+
 "Fire Temple Pre-Boss":
   dungeon: Fire
   exits:
@@ -60,6 +67,7 @@
     "Fire Temple Pre-Boss Room Cell Corner": "has_tunic_goron && (is_adult || (can_hookshot || has_hover_boots || climb_anywhere))"
     "Fire Temple Pre-Boss Room Tall Ledges Corner": "has_tunic_goron && (can_hookshot || has_hover_boots || climb_anywhere)"
     "Fire Temple Boss": "boss_key(BOSS_KEY_FIRE)"
+
 "Fire Temple Pre-Boss Room Tall Ledges Corner":
   dungeon: Fire
   exits:
@@ -74,6 +82,7 @@
     "MQ Fire Temple Pre-Boss Room Tall Ledge Low Large Crate 2": "has_tunic_goron"
     "MQ Fire Temple Pre-Boss Room Tall Ledge Middle Large Crate": "has_tunic_goron" #Child can reach this by jumping off the hookshot platform that has the torch.
     "MQ Fire Temple Pre-Boss Room Tall Ledge Top Large Crate": "has_tunic_goron" #Child can reach this by using the middle crate as a platform.
+
 "Fire Temple Hammer Loop Enemies Room":
   dungeon: Fire
   exits:
@@ -83,6 +92,7 @@
     FIRE_MQ_HAMMER_LOOP_FIRST_CLEAR: "has_weapon && soul_keese && soul_enemy(SOUL_ENEMY_STALFOS)"
   locations:
     "MQ Fire Temple Hammer Loop Stalfos Big Fairy": "can_play_sun"
+
 "Fire Temple Hammer Loop Iron Knuckle Room":
   dungeon: Fire
   exits:
@@ -100,6 +110,7 @@
     "MQ Fire Temple Pot Hammer Loop 7": "true"
     "MQ Fire Temple Pot Hammer Loop 8": "true"
     "MQ Fire Temple Hammer Loop Iron Knuckle Big Fairy": "can_play_sun"
+
 "Fire Temple Hammer Loop Flare Dancer Room":
   dungeon: Fire
   exits:
@@ -109,6 +120,7 @@
     FIRE_MQ_HAMMER_LOOP_FLARE_DANCER_CLEAR: "soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (has_bombs || has_bombchu || can_use_mask_blast || can_hammer || can_hookshot) && (has_weapon || has_sticks || can_hammer)"
   locations:
     "MQ Fire Temple Hammer Chest": "event(FIRE_MQ_HAMMER_LOOP_FLARE_DANCER_CLEAR) && (is_adult || can_hookshot || climb_anywhere)"
+
 "Fire Temple Hammer Loop Goron Cell Map Chest Side":
   dungeon: Fire
   exits:
@@ -118,6 +130,7 @@
     FIRE_MQ_MAP_CHEST_HAMMER_SWITCH: "can_hammer"
   locations:
     "MQ Fire Temple Map Chest": "event(FIRE_MQ_MAP_CHEST_HAMMER_SWITCH)"
+
 "Fire Temple 1F Lava Bridge Room Main":
   dungeon: Fire
   exits:
@@ -129,6 +142,7 @@
     "Fire Temple Rising Block Room": "has_tunic_goron && small_keys_fire_mq(2)"
   locations:
     "MQ Fire Temple Pot Lava Room Left": "has_tunic_goron"
+
 "Fire Temple 1F Lava Bridge Room High Alcove":
   dungeon: Fire
   exits:
@@ -137,11 +151,13 @@
     FIRE_MQ_LAVA_BRIDGE_ROOM_TORCHES: "has_fire" #Might need to separate intwo two events when action shuffle happens.
   locations:
     "MQ Fire Temple Pot Lava Room Alcove": "has_tunic_goron"
+
 "Fire Temple Lava Bridge Room North Side Upper Ledge":
   dungeon: Fire
   exits:
     "Fire Temple 1F Lava Bridge Room Main": "has_tunic_goron"
     "Fire Temple Boss Key Chest Room": "has_tunic_goron && event(FIRE_MQ_LAVA_BRIDGE_ROOM_TORCHES)"
+
 "Fire Temple Boss Key Chest Room":
   dungeon: Fire
   exits:
@@ -152,12 +168,14 @@
     "MQ Fire Temple Pot Boss Key Room 2": "can_hookshot || can_boomerang || climb_anywhere"
     "MQ Fire Temple Wonder Item Boss Key Room Hookshot": "can_hookshot"
     "MQ Fire Temple Wonder Item Boss Key Room Bow": "can_use_bow && (can_boomerang || can_hookshot || climb_anywhere)"
+
 "Fire Temple Lava Bridge Room North Side Lower Room":
   dungeon: Fire
   exits:
     "Fire Temple 1F Lava Bridge Room Main": "true"
   locations:
     "MQ Fire Temple GS 1f Lava Room": "gs && can_hammer"
+
 "Fire Temple Lava Bridge Room South Side Ledge":
   dungeon: Fire
   exits:
@@ -167,12 +185,14 @@
     FIRE_MQ_LAVA_BRIDGE_ROOM_HOOKSHOT_PLATFORMS: "has_fire"
   locations:
     "MQ Fire Temple Pot Lava Room Right": "has_tunic_goron"
+
 "Fire Temple 1F Lava Bridge Room South Side Room":
   dungeon: Fire
   exits:
     "Fire Temple Lava Bridge Room South Side Ledge": "true"
   locations:
     "MQ Fire Temple 1f Lava Room Goron Chest": "has_fire"
+
 "Fire Temple Rising Block Room":
   dungeon: Fire
   exits:
@@ -182,6 +202,7 @@
     "MQ Fire Temple Heart 1": "has_tunic_goron_strict"
     "MQ Fire Temple Heart 2": "has_tunic_goron_strict"
     "MQ Fire Temple Heart 3": "has_tunic_goron_strict"
+
 "Fire Temple Room Before Maze":
   dungeon: Fire
   exits:
@@ -194,6 +215,7 @@
     "MQ Fire Temple Wonder Item Shortcut Room 1": "can_hammer"
     "MQ Fire Temple Wonder Item Shortcut Room 2": "can_hammer"
     "MQ Fire Temple Wonder Item Shortcut Room 3": "can_hammer"
+
 "Fire Temple Shortcut Cage Under Maze":
   dungeon: Fire
   exits:
@@ -209,6 +231,7 @@
     "MQ Fire Temple Cell Below Maze Large Crate 4": "true"
     "MQ Fire Temple Cell Below Maze Large Crate 5": "true"
     "MQ Fire Temple Cell Below Maze Large Crate 6": "true"
+
 "Fire Temple Maze Room Lower":
   dungeon: Fire
   exits:
@@ -228,12 +251,14 @@
     "MQ Fire Temple Maze Room Lower Cage Large Crate 1": "event(FIRE_MQ_MAZE_ROOM_LOWER_CAGE_SWITCH)"
     "MQ Fire Temple Maze Room Lower Cage Large Crate 2": "event(FIRE_MQ_MAZE_ROOM_LOWER_CAGE_SWITCH)"
     "MQ Fire Temple Maze Room Lower Cage Large Crate 3": "event(FIRE_MQ_MAZE_ROOM_LOWER_CAGE_SWITCH)"
+
 "Fire Temple Maze Room Rusty Switch Behind Bombable Wall":
   dungeon: Fire
   exits:
     "Fire Temple Maze Room Lower": "true"
   events:
     FIRE_MQ_MAZE_ROOM_LOWER_RUSTY_SWITCH: "can_hammer"
+
 "Fire Temple Maze Room Blue Switch Behind Bombable Wall":
   dungeon: Fire
   exits:
@@ -241,6 +266,7 @@
     "Fire Temple Maze Room Side Room": "event(FIRE_MQ_MAZE_ROOM_BLUE_SWITCH)"
   events:
    FIRE_MQ_MAZE_ROOM_BLUE_SWITCH: "can_play_elegy"
+
 "Fire Temple Maze Room Upper Switch Cage Alcove":
   dungeon: Fire
   exits:
@@ -255,12 +281,14 @@
     "MQ Fire Temple Maze Room Upper Cage Large Crate 3": "true"
     "MQ Fire Temple Maze Room Upper Cage Small Crate 1": "true"
     "MQ Fire Temple Maze Room Upper Cage Small Crate 2": "true"
+
 "Fire Temple Maze Room Side Room":
   dungeon: Fire
   exits:
     "Fire Temple Maze Room Blue Switch Behind Bombable Wall": "true"
   locations:
     "MQ Fire Temple Maze Side Room Chest": "true"
+
 "Fire Temple Maze Room Upper":
   dungeon: Fire
   exits:
@@ -269,12 +297,14 @@
     "Fire Temple Shortcut Cage Under Maze": "has_explosives"
     "Fire Temple 3F Lava Floor Room After Maze": "small_keys_fire_mq(3)"
     "Fire Temple Tower Area Above Maze Room": "can_longshot || (can_play_time && can_hookshot) || hookshot_anywhere || climb_anywhere"
+
 "Fire Temple Tower Area Above Maze Room":
   dungeon: Fire
   exits:
     "Fire Temple Maze Room Upper": "true"
     "Fire Temple Maze Room Lower": "true"
     "Fire Temple Tower Above Maze First Room": "true"
+
 "Fire Temple Tower Above Maze First Room":
   dungeon: Fire
   exits:
@@ -285,6 +315,7 @@
     "MQ Fire Temple Wonder Item East Climb First 2": "can_hookshot"
     "MQ Fire Temple Wonder Item East Climb Second 1": "can_hookshot"
     "MQ Fire Temple Wonder Item East Climb Second 2": "can_hookshot"
+
 "Fire Temple Tower Above Maze Burning Block Room":
   dungeon: Fire
   exits:
@@ -295,6 +326,7 @@
     FIRE_MQ_EAST_TOWER_TOP_HOOKSHOT_TARGETS: "can_hammer"
   locations:
     "MQ Fire Temple GS Burning Block": "gs && ((event(FIRE_MQ_EAST_TOWER_TOP_HOOKSHOT_TARGETS) && can_hookshot) || hookshot_anywhere || climb_anywhere)" #TODO: add a trick for getting it with boomerang
+
 "Fire Temple 3F Lava Floor Room After Maze":
   dungeon: Fire
   exits:
@@ -317,6 +349,7 @@
     "MQ Fire Temple 3F Lava Room Near Cage Large Crate": "has_tunic_goron && (can_hookshot || climb_anywhere)" #TODO: trick for adult walking along the edge of cage
     "MQ Fire Temple 3F Lava Room Near Cage Small Crate 1": "has_tunic_goron && (can_hookshot || climb_anywhere)" #TODO: trick for adult walking along the edge of cage
     "MQ Fire Temple 3F Lava Room Near Cage Small Crate 2": "has_tunic_goron && (can_hookshot || climb_anywhere)" #TODO: trick for adult walking along the edge of cage
+
 "Fire Temple 3F Lava Room Ledge Before Fire Walls Hallway":
   dungeon: Fire
   exits:
@@ -325,11 +358,13 @@
   locations:
     "MQ Fire Temple 3F Lava Room High Ledge Large Crate": "has_tunic_goron"
     "MQ Fire Temple 3F Lava Room High Ledge Small Crate": "has_tunic_goron"
+
 "Fire Temple 3F Lava Room Cage Area":
   dungeon: Fire
   exits:
     "Fire Temple 3F Lava Floor Room After Maze": "can_hookshot || climb_anywhere"
     "Fire Temple Inside Maze Narrow Paths Room": "true"
+
 "Fire Temple Inside Maze Narrow Paths Room":
   dungeon: Fire
   exits:
@@ -341,11 +376,13 @@
     "MQ Fire Temple Pot Bridge Above Lava Room 1": "true"
     "MQ Fire Temple Pot Bridge Above Lava Room 2": "true"
     "MQ Fire Temple Pot Bridge Above Lava Room 3": "true"
+
 "Fire Temple 3F Hallway Before Fire Walls":
   dungeon: Fire
   exits:
     "Fire Temple 3F Lava Room Ledge Before Fire Walls Hallway": "true"
     "Fire Temple Fire Walls Room Pillar Side": "true"
+
 "Fire Temple Fire Walls Room Pillar Side":
   dungeon: Fire
   exits:
@@ -364,6 +401,7 @@
   locations:
     "MQ Fire Temple Pot Fire Maze Room Left 1": "true"
     "MQ Fire Temple Pot Fire Maze Room Left 2": "true"
+
 "Fire Temple Fire Walls Room Outside Side Room":
   dungeon: Fire
   exits:
@@ -374,12 +412,14 @@
   locations:
     "MQ Fire Temple Pot Fire Maze Room Right 1": "true"
     "MQ Fire Temple Pot Fire Maze Room Right 2": "true"
+
 "Fire Temple Fire Walls Room Side Room":
   dungeon: Fire
   exits:
     "Fire Temple Fire Walls Room Outside Side Room": "true"
   locations:
     "MQ Fire Temple GS Fire Walls Side Room": "gs && can_damage_skull"
+
 "Fire Temple Fire Walls Middle Hallway Lower":
   dungeon: Fire
   exits:
@@ -388,6 +428,7 @@
     "Fire Temple Fire Walls Middle Hallway Upper": "hookshot_anywhere || climb_anywhere"
   locations:
     "MQ Fire Temple GS Fire Walls Middle": "gs && has_explosives"
+
 "Fire Temple Fire Walls Middle Hallway Upper":
   dungeon: Fire
   exits:
@@ -395,6 +436,7 @@
     "Fire Temple Fire Walls Room Pillar Side": "true"
   events:
     FIRE_MQ_FIRE_WALLS_MIDDLE_ROOM_RUSTY_SWITCH: "can_hammer && (can_hookshot || climb_anywhere)"
+
 "Fire Temple Fire Walls Room Large Fire Wall Side":
   dungeon: Fire
   exits:
@@ -405,6 +447,7 @@
   locations:
     "MQ Fire Temple Pot Fire Maze Room Right 1": "can_boomerang"
     "MQ Fire Temple Pot Fire Maze Room Right 2": "can_boomerang"
+
 "Fire Temple Fire Walls Room Area After Large Fire Wall":
   dungeon: Fire
   exits:
@@ -414,6 +457,7 @@
     "MQ Fire Temple Pot Fire Maze Room Back Right 1": "true"
     "MQ Fire Temple Pot Fire Maze Room Back Right 2": "true"
     "MQ Fire Temple Wonder Item Fire Maze": "can_hookshot"
+
 "Fire Temple Flare Dancer Room After Fire Walls":
   dungeon: Fire
   exits:
@@ -423,6 +467,7 @@
     FIRE_MQ_FLARE_DANCER_AFTER_FIRE_WALLS: "soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (has_bombs || has_bombchu || can_use_mask_blast || can_hammer || can_hookshot) && (has_weapon || has_sticks || can_hammer)"
   locations:
     "MQ Fire Temple Flare Dancer Key": "event(FIRE_MQ_FLARE_DANCER_AFTER_FIRE_WALLS)" #TODO: trick to get with boomerang
+
 "Fire Temple Tower After Flare Dancer First Room":
   dungeon: Fire
   exits:
@@ -430,6 +475,7 @@
     "Fire Temple Tower After Flare Dancer Pit Room": "small_keys_fire_mq(4)"
   locations:
     "MQ Fire Temple Wonder Item After Flare Dancer": "can_hookshot"
+
 "Fire Temple Tower After Flare Dancer Pit Room":
   dungeon: Fire
   exits:
@@ -441,6 +487,7 @@
     FIRE_MQ_TOWER_AFTER_FLARE_DANCER_HOOKSHOT_TARGETS: "has_weapon || has_bombs || can_use_mask_blast || has_bombchu || can_use_bow || can_use_slingshot || can_hookshot || can_use_sticks || can_hammer || can_boomerang" #Many ways to hit crystal switch. Are they even useful in this section?
   locations:
     "MQ Fire Temple Topmost Chest": "is_adult || (scarecrow_hookshot || climb_anywhere || hookshot_anywhere)" #Child can't do it without these.
+
 "Fire Temple Tower After Flare Dancer Area Before Staircase":
   dungeon: Fire
   exits:
@@ -448,6 +495,7 @@
     "Fire Temple Tower After Flare Dancer Staircase Upper": "small_keys_fire_mq(5)"
   events:
     FIRE_MQ_TOWER_AFTER_FLARE_DANCER_CRYSTAL_SWITCH_FROM_BELOW: "event(FIRE_MQ_TOWER_TOP_HAMMER_SWITCH_BEFORE_STAIRCASE) && (has_ranged_weapon || has_bombchu)"
+
 "Fire Temple Tower After Flare Dancer Staircase Upper":
   dungeon: Fire
   exits:
@@ -457,11 +505,13 @@
     FIRE_MQ_STAIRCASE_LOWERED: "can_hammer"
   locations:
     "MQ Fire Temple Wonder Item Staircase": "event(FIRE_MQ_STAIRCASE_LOWERED) && can_hookshot"
+
 "Fire Temple Tower After Flare Dancer Staircase Lower Alcove":
   dungeon: Fire
   exits:
     "Fire Temple Tower After Flare Dancer Staircase Upper": "event(FIRE_MQ_STAIRCASE_LOWERED)"
     "Fire Temple Fire Walls Room High Area After Staircase": "event(FIRE_MQ_STAIRCASE_LOWERED) && can_hookshot"
+
 "Fire Temple Fire Walls Room High Area After Staircase":
   dungeon: Fire
   exits:

--- a/data/world/oot/dungeons_mq/forest_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/forest_temple_mq.yml
@@ -4,14 +4,17 @@
     "GLOBAL": "true"
     "Sacred Meadow Forest Platform": "true"
     "Forest Temple Entrance Room": "true"
+
 "Forest Temple Wallmaster West":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Forest Temple Wallmaster East":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Forest Temple Entrance Room":
   dungeon: Forest
   exits: #Maybe make the upper branches where the event takes place its own region?
@@ -21,16 +24,19 @@
     FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH: "can_longshot || climb_anywhere || (has_nuts || can_hit_triggers_distance || can_hookshot || has_hover_boots || can_use_din || has_bomb_bag || can_use_mask_stone || (has_weapon && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))))" #Many ways to deal with the Skulltula in the way.
   locations:
     "MQ Forest Temple First Room Chest": "event(FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH)"
+
 "Forest Temple Initial Hallway Front":
   dungeon: Forest
   exits:
     "Forest Temple Entrance Room": "true"
     "Forest Temple Initial Hallway Navigation": "get_past_skultullas"
+
 "Forest Temple Initial Hallway Navigation": #Even more ways to get past the skultulas. Region exists for enemy drops rando, and for ease of placing the door regions for door rando.
   dungeon: Forest
   exits:
     "Forest Temple Initial Hallway Front": "get_past_skultullas"
     "Forest Temple Initial Hallway Back": "get_past_skultullas"
+
 "Forest Temple Initial Hallway Back":
   dungeon: Forest
   exits:
@@ -38,6 +44,7 @@
     "Forest Temple Main Lobby": "small_keys_forest(1)"
   locations:
     "MQ Forest Temple GS Entryway": "gs && (can_collect_distance || ((has_ranged_weapon || has_explosives) && climb_anywhere))" #Blast mask too? Need to have separate macros for close vs far-range explosives...
+
 "Forest Temple Main Lobby":
   dungeon: Forest
   exits: #TODO: Regions for the pot ledges for Action Shuffle
@@ -59,16 +66,19 @@
     "MQ Forest Temple Pot Main Room 4": "true"
     "MQ Forest Temple Pot Main Room 5": "true"
     "MQ Forest Temple Pot Main Room 6": "true"
+
 "Forest Temple Main Lobby Upper East Ledge":
   dungeon: Forest
   exits:
     "Forest Temple Main Lobby": "true"
     "Forest Temple Hallway Between Green Poe Room And Lobby": "true"
+
 "Forest Temple Hallway Before Lower Section Of Stalfos Battle Room":
   dungeon: Forest
   exits:
     "Forest Temple Main Lobby": "true"
     "Forest Temple Lower Section Of Stalfos Battle Room": "is_child || can_play_time" #Will need more handling for the SoT block when door rando logic is added.
+
 "Forest Temple Lower Section Of Stalfos Battle Room":
   dungeon: Forest
   exits:
@@ -83,6 +93,7 @@
     "MQ Forest Temple Pot Bow Room Upper 2": "hookshot_anywhere"
     "MQ Forest Temple Pot Bow Room Upper 3": "hookshot_anywhere"
     "MQ Forest Temple Pot Bow Room Upper 4": "hookshot_anywhere"
+
 "Forest Temple Hallway Before Climbing Block Puzzle Room":
   dungeon: Forest
   exits:
@@ -90,6 +101,7 @@
     "Forest Temple Climbing Block Puzzle Room Ground Floor": "event(FOREST_MQ_HALLWAY_BEFORE_CLIMBING_BLOCKS_STALFOS_CLEAR)"
   events:
     FOREST_MQ_HALLWAY_BEFORE_CLIMBING_BLOCKS_STALFOS_CLEAR: "soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon"
+
 "Forest Temple Climbing Block Puzzle Room Ground Floor":
   dungeon: Forest
   exits: #Separating floors now in preparation for action shuffle.
@@ -105,6 +117,7 @@
     FOREST_MQ_CLIMBING_BLOCK_ROOM_ICE_PLATFORM_SHORTCUT: "has_bombchu"
   locations:
     "MQ Forest Temple GS Climb Room": "gs && can_damage_skull"
+
 "Forest Temple Climbing Block Puzzle Room Crystal Switch Alcove":
   dungeon: Forest
   exits:
@@ -113,6 +126,7 @@
   events:
     FOREST_MQ_CLIMBING_BLOCK_ROOM_ALCOVE_SWITCH_CLOSE: "can_hit_crystal_switch_close"
     FOREST_MQ_CLIMBING_BLOCK_ROOM_ALCOVE_SWITCH_FAR: "has_bombs"
+
 "Forest Temple Climbing Block Puzzle Room First Block Floor":
   dungeon: Forest
   exits:
@@ -122,6 +136,7 @@
     "Forest Temple Climbing Block Puzzle Room After Second Block Floor Crystal Switch Landing": "event(FOREST_MQ_SECOND_PUSH_BLOCK_PUZZLE_CLEAR)"
   events:
     FOREST_MQ_FIRST_PUSH_BLOCK_PUZZLE_CLEAR: "has_goron_bracelet"
+
 "Forest Temple Climbing Block Puzzle Room First Block Floor Outer Ledge":
   dungeon: Forest
   exits:
@@ -130,6 +145,7 @@
     "Forest Temple Climbing Block Puzzle Room First Block Floor": "event(FOREST_MQ_FIRST_PUSH_BLOCK_PUZZLE_CLEAR) || has_hover_boots || hookshot_anywhere || climb_anywhere"
     "Forest Temple Climbing Block Puzzle Room Second Block Floor": "event(FOREST_MQ_FIRST_PUSH_BLOCK_PUZZLE_CLEAR) || hookshot_anywhere || (is_adult && event(FOREST_MQ_CLIMBING_BLOCK_ROOM_ICE_PLATFORM_SHORTCUT))"
     "Forest Temple Climbing Block Puzzle Room After Second Block Floor Crystal Switch Landing": "(event(FOREST_MQ_CLIMBING_BLOCK_ROOM_ICE_PLATFORM_SHORTCUT) && can_hookshot) || hookshot_anywhere"
+
 "Forest Temple Climbing Block Puzzle Room Second Block Floor":
   dungeon: Forest
   exits:
@@ -139,6 +155,7 @@
   events:
     FOREST_MQ_CLIMBING_BLOCK_ROOM_ICE_PLATFORM_SHORTCUT: "can_hit_triggers_distance || can_longshot" #Can hit it if you stand near the guard rails
     FOREST_MQ_SECOND_PUSH_BLOCK_PUZZLE_CLEAR: "(has_goron_bracelet && event(FOREST_MQ_FIRST_PUSH_BLOCK_PUZZLE_CLEAR) && is_adult) || hookshot_anywhere || climb_anywhere" #A little redundant, yes, but it is a separate flag. Also ground jump glitch?
+
 "Forest Temple Climbing Block Puzzle Room After Second Block Floor Crystal Switch Landing":
   dungeon: Forest
   exits:
@@ -147,11 +164,13 @@
     "Forest Temple Climbing Block Puzzle Room Top Floor": "true"
   events:
     FOREST_MQ_CLIMBING_BLOCK_ROOM_ICE_PLATFORM_SHORTCUT: "can_hit_crystal_switch_close"
+
 "Forest Temple Climbing Block Puzzle Room Top Floor":
   dungeon: Forest
   exits:
     "Forest Temple Climbing Block Puzzle Room After Second Block Floor Crystal Switch Landing": "true"
     "Forest Temple Western Twisting Hallway Block Push Side": "small_keys_forest(3)"
+
 "Forest Temple Western Twisting Hallway Block Push Side":
   dungeon: Forest
   exits:
@@ -161,6 +180,7 @@
     "Forest Temple Western Twisting Hallway Red Poe Side": "event(FOREST_MQ_CLIMBING_BLOCK_ROOM_ALCOVE_SWITCH_CLOSE) || event(FOREST_MQ_CLIMBING_BLOCK_ROOM_ALCOVE_SWITCH_EARLY)"
   locations:
     "MQ Forest Temple Boss Key Chest": "event(FOREST_MQ_CLIMBING_BLOCK_ROOM_ALCOVE_SWITCH_FAR)"
+
 "Forest Temple Floormaster Battle Room Below Hallway":
   dungeon: Forest
   exits:
@@ -170,6 +190,7 @@
     "MQ Forest Temple Boss Key Chest": "hookshot_anywhere && climb_anywhere" #This and an exit to the Block Push Side will need looked at again once door rando is being implemented.
   events:
     FOREST_MQ_FLOORMASTER_BATTLE_BELOW_HALLWAY_CLEAR: "soul_floormaster && has_weapon" #Placeholder for now.
+
 "Forest Temple West Garden Upper Ledge Hallway":
   dungeon: Forest
   exits:
@@ -181,6 +202,7 @@
     "Forest Temple West Garden Ledge Above Well": "has_hover_boots || hookshot_anywhere || climb_anywhere"
   events:
     FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire_arrows"
+
 "Forest Temple West Garden Pillar With Items":
   dungeon: Forest
   exits:
@@ -190,6 +212,7 @@
     "MQ Forest Temple Heart Garden 1": "true"
     "MQ Forest Temple Heart Garden 2": "true"
     "MQ Forest Temple Heart Garden 3": "true"
+
 "Forest Temple West Garden Redead Battle Room":
   dungeon: Forest
   exits:
@@ -198,6 +221,7 @@
     FOREST_MQ_WEST_GARDEN_REDEAD_BATTLE_CLEAR: "soul_redead_gibdo && has_weapon" #Placeholder
   locations:
     "MQ Forest Temple ReDead Chest": "event(FOREST_MQ_WEST_GARDEN_REDEAD_BATTLE_CLEAR)"
+
 "Forest Temple West Garden Ledge Above Well":
   dungeon: Forest
   exits:
@@ -207,6 +231,7 @@
     FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire_arrows"
   locations:
     "MQ Forest Temple GS West Garden": "gs && can_damage_skull"
+
 "Forest Temple West Garden Ground Area":
   dungeon: Forest
   exits:
@@ -219,6 +244,7 @@
     "Forest Temple East Garden Ground Area": "(has_tunic_zora && can_dive_big) || event(FOREST_MQ_DRAIN_WELL)" #Not part of Well region because diving with scale can't get checks.
   events:
     FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire_arrows"
+
 "Forest Temple West Garden Webbed Alcove":
   dungeon: Forest
   exits:
@@ -226,6 +252,7 @@
     "Forest Temple Linking Room Between Gardens Behind Web": "true"
   events:
     FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire"
+
 "Forest Temple Linking Room Between Gardens Behind Web":
   dungeon: Forest
   exits:
@@ -233,6 +260,7 @@
     "Forest Temple Linking Room Between Gardens": "event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY)"
   events:
     FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire"
+
 "Forest Temple Linking Room Between Gardens":
   dungeon: Forest
   exits:
@@ -240,6 +268,7 @@
     "Forest Temple Linking Room Between Gardens Behind Web": "event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY)"
   events:
     FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "can_use_din || has_arrows"
+
 "Forest Temple Gardens Well":
   dungeon: Forest
   exits:
@@ -251,6 +280,7 @@
     "MQ Forest Temple Heart Well 1": "true"
     "MQ Forest Temple Heart Well 2": "true"
     "MQ Forest Temple Heart Well 3": "true"
+
 "Forest Temple East Garden Top Balcony With Door":
   dungeon: Forest
   exits:
@@ -258,6 +288,7 @@
     "Forest Temple East Garden Ground Area": "true"
     "Forest Temple East Garden Top Balcony With Chest": "true" #action rando will need a trick to do this with nothing.
     "Forest Temple East Garden Above GS Awning": "is_adult && can_play_time" #Child can do this but is inconsistent. Can be a trick later on, as well as "3-key Forest."
+
 "Forest Temple East Garden Top Balcony With Chest":
   dungeon: Forest
   exits:
@@ -266,6 +297,7 @@
     #"Forest Temple East Garden Hill With Chest": "has_hover_boots && trick(insert trick here) This is similar to doing "3-Key Forest," so should be behind a trick.
   locations:
     "MQ Forest Temple East Garden High Ledge Chest": "true"
+
 "Forest Temple East Garden Hill With Chest":
   dungeon: Forest
   exits:
@@ -276,11 +308,13 @@
   events:
     STICKS: "soul_deku_baba && (can_boomerang || (has_nuts && has_weapon))"
     NUTS: "soul_deku_baba && (has_weapon || can_hammer || can_hookshot || has_mask_blast || has_explosives || can_hit_triggers_distance)"
+
 "Forest Temple East Garden Water Ledge With Door":
   dungeon: Forest
   exits:
     "Forest Temple Checkerboard Room": "true"
     "Forest Temple East Garden Hill With Chest": "true"
+
 "Forest Temple East Garden Above GS Awning":
   dungeon: Forest
   exits: #This awning region exists to account for the time block method from the upper balconies.
@@ -288,6 +322,7 @@
     "Forest Temple East Garden Top Balcony With Chest": "can_play_time"
   locations:
     "MQ Forest Temple GS East Garden": "gs && (has_explosives || has_ranged_weapon || can_use_din || ((can_use_sword_kokiri || can_use_sword_master || can_use_sword_biggoron || can_use_sticks) && has_one_hand_shield) || ((is_child || has_shield || climb_anywhere) && has_mask_blast))"
+
 "Forest Temple East Garden Ground Area":
   dungeon: Forest
   exits:
@@ -304,11 +339,13 @@
     STICKS: "soul_deku_baba && (can_boomerang || (has_nuts && has_weapon))"
     NUTS: "soul_deku_baba && (has_weapon || can_hookshot || can_hammer || has_mask_blast || has_explosives || can_hit_triggers_distance)"
     FOREST_MQ_DRAIN_WELL: "can_hit_triggers_distance"
+
 "Forest Temple Western Twisting Hallway Red Poe Side":
   dungeon: Forest
   exits:
     "Forest Temple Western Twisting Hallway Block Push Side": "event(FOREST_MQ_CLIMBING_BLOCK_ROOM_ALCOVE_SWITCH_CLOSE) || event(FOREST_MQ_CLIMBING_BLOCK_ROOM_ALCOVE_SWITCH_EARLY)"
     "Forest Temple Red Poe Paintings Room": "small_keys_forest(4)"
+
 "Forest Temple Red Poe Paintings Room":
   dungeon: Forest
   exits:
@@ -318,6 +355,7 @@
     "MQ Forest Temple Map Chest": "event(FOREST_MQ_JOELLE_CLEAR)"
   events:
     FOREST_MQ_JOELLE_CLEAR: "soul_poe && can_use_bow"
+
 "Forest Temple Upper Section Of Stalfos Battle Room":
   dungeon: Forest
   exits:
@@ -332,6 +370,7 @@
   events:
     FOREST_MQ_BOW_ROOM_STALFOS_BATTLE_CLEAR: "event(FOREST_MQ_UNDER_STALFOS_BATTLE_WOLFOS_CLEAR) && soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon"
     FOREST_MQ_UNDER_STALFOS_BATTLE_WOLFOS_CLEAR: "soul_wolfos && (has_weapon || can_use_slingshot || has_explosives || can_use_din || can_use_sticks)"
+
 "Forest Temple Blue Poe Paintings Room":
   dungeon: Forest
   exits:
@@ -344,6 +383,7 @@
     "MQ Forest Temple Pot Blue Poe 3": "true"
   events:
     FOREST_MQ_BETH_CLEAR: "soul_poe && can_use_bow"
+
 "Forest Temple Eastern Twisting Hallway Blue Poe Side":
   dungeon: Forest
   exits:
@@ -351,6 +391,7 @@
     "Forest Temple Eastern Twisting Hallway Red Pool Side": "true"
     "Forest Temple Checkerboard Room": "event(FOREST_MQ_SPINNING_RED_POOLS_FROZEN_EYE)"
     "Forest Temple Wallmaster East": "soul_wallmaster"
+
 "Forest Temple Eastern Twisting Hallway Red Pool Side":
   dungeon: Forest
   exits:
@@ -358,6 +399,7 @@
     "Forest Temple Spinning Red Pool Room": "small_keys_forest(6)"
     "Forest Temple Checkerboard Room": "event(FOREST_MQ_SPINNING_RED_POOLS_FROZEN_EYE)"
     "Forest Temple Wallmaster East": "soul_wallmaster"
+
 "Forest Temple Spinning Red Pool Room":
   dungeon: Forest
   exits:
@@ -368,6 +410,7 @@
     "MQ Forest Temple Spinning Red Pool Room Small Crate 3": "true"
   events:
     FOREST_MQ_SPINNING_RED_POOLS_FROZEN_EYE: "can_use_bow || has_fire" #Elegy when action shuffle for carrying crates.
+
 "Forest Temple Checkerboard Room":
   dungeon: Forest
   exits:
@@ -379,6 +422,7 @@
   events:
     FOREST_MQ_CHECKERBOARD_SWITCH_GARDEN_DOOR: "true"
     FOREST_MQ_CHECKERBOARD_SWITCH_CHEST: "true"
+
 "Forest Temple Green Poe Painting Room":
   dungeon: Forest
   exits:
@@ -389,11 +433,13 @@
     "MQ Forest Temple Pot Green Poe 2": "true"
   events:
     FOREST_MQ_AMY_CLEAR: "soul_poe && can_use_bow"
+
 "Forest Temple Hallway Between Green Poe Room And Lobby":
   dungeon: Forest
   exits:
     "Forest Temple Green Poe Painting Room": "true"
     "Forest Temple Main Lobby Upper East Ledge": "true"
+
 "Forest Temple Antichamber Center":
   dungeon: Forest
   exits:
@@ -405,6 +451,7 @@
     "Forest Temple Antichamber Room Hallway Before Boss": "event(FOREST_MQ_ANTICHAMBER_SOUTH_ALCOVE_EYE_SWITCH)"
   events:
     FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_CRYSTAL_SWITCH: "has_ranged_weapon || has_explosives || has_mask_blast || can_use_sticks || can_use_sword_biggoron || (is_adult && (can_use_sword_master || can_hammer))" #razor? gilded? adult+kokiri?
+
 "Forest Temple Antichamber Room Southwest Alcove":
   dungeon: Forest
   exits:
@@ -414,24 +461,28 @@
     "MQ Forest Temple Pot Antichamber 2": "true"
     "MQ Forest Temple Pot Antichamber 3": "true"
     "MQ Forest Temple Pot Antichamber 4": "true"
+
 "Forest Temple Antichamber Room East Alcove":
   dungeon: Forest
   exits:
     "Forest Temple Antichamber Center": "true"
   events:
     FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_FLOOR_SWITCH: "true"
+
 "Forest Temple Antichamber Room Northwest Alcove":
   dungeon: Forest
   exits:
     "Forest Temple Antichamber Center": "true"
   locations:
     "MQ Forest Temple Antichamber": "true"
+
 "Forest Temple Antichamber Room South Alcove":
   dungeon: Forest
   exits:
     "Forest Temple Antichamber Center": "true"
   events:
     FOREST_MQ_ANTICHAMBER_SOUTH_ALCOVE_EYE_SWITCH: "can_hit_triggers_distance"
+
 "Forest Temple Antichamber Room Hallway Before Boss":
   dungeon: Forest
   exits:

--- a/data/world/oot/dungeons_mq/ganon_castle_mq.yml
+++ b/data/world/oot/dungeons_mq/ganon_castle_mq.yml
@@ -5,10 +5,12 @@
     "Ganon Castle Main Room": "event(MQ_GANON_OPEN_MAIN)"
   events:
     MQ_GANON_OPEN_MAIN: "soul_iron_knuckle && soul_armos && soul_bubble && (can_use_sword_master || can_use_sword_goron || (can_use_sticks && (has_ranged_weapon_child || can_use_bow)) || has_explosives_or_hammer)"
+
 "Ganon Castle Spirit Wallmaster":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Ganon Castle Main Room":
   dungeon: Ganon
   exits:
@@ -21,6 +23,7 @@
     "Ganon Castle Shadow Trial Entrance Side": "true"
     "Ganon Castle Stairs": "ganon_barrier"
     "Ganon Castle Fairy Fountain": "has_lens"
+
 "Ganon Castle Fairy Fountain":
   dungeon: Ganon
   exits:
@@ -39,6 +42,7 @@
     "MQ Ganon Castle Fairy Fountain Fairy 6": "true"
     "MQ Ganon Castle Fairy Fountain Fairy 7": "true"
     "MQ Ganon Castle Fairy Fountain Fairy 8": "true"
+
 "Ganon Castle Light Trial Entrance":
   dungeon: Ganon
   exits:
@@ -46,6 +50,7 @@
     "Ganon Castle Light Trial Lullaby Hallway": "event(GANON_MQ_LIGHT_ENEMIES)"
   events:
     GANON_MQ_LIGHT_ENEMIES: "soul_lizalfos_dinolfos && soul_enemy(SOUL_ENEMY_TORCH_SLUG) && (has_weapon || (can_hammer && can_use_sticks))"
+
 "Ganon Castle Light Trial Lullaby Hallway":
   dungeon: Ganon
   exits:
@@ -53,11 +58,13 @@
     "Ganon Castle Light Trial Round Boulder Room Before Flame Walls": "small_keys_ganon(2)"
   locations:
     "MQ Ganon Castle Light Trial Chest": "song_event(0x11)"
+
 "Ganon Castle Light Trial Round Boulder Room Before Flame Walls":
   dungeon: Ganon
   exits:
     "Ganon Castle Light Trial Lullaby Hallway": "small_keys_ganon(2)"
     "Ganon Castle Light Trial Round Boulder Room After Flame Walls": "can_hookshot || climb_anywhere"
+
 "Ganon Castle Light Trial Round Boulder Room After Flame Walls":
   dungeon: Ganon
   exits:
@@ -66,6 +73,7 @@
   locations:
     "MQ Ganon Castle Heart Light 1": "true"
     "MQ Ganon Castle Heart Light 2": "true"
+
 "Ganon Castle Light Trial Ending Room":
   dungeon: Ganon
   exits:
@@ -75,6 +83,7 @@
   locations:
     "MQ Ganon Pot Light End 1": "true"
     "MQ Ganon Pot Light End 2": "true"
+
 "Ganon Castle Forest Trial Entrance":
   dungeon: Ganon
   exits:
@@ -84,6 +93,7 @@
     GANON_MQ_FOREST_ENEMIES: "soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon"
   locations:
     "MQ Ganon Castle Forest Trial Key": "can_hookshot || can_boomerang || climb_anywhere"
+
 "Ganon Castle Forest Trial Wind Room Starting Side":
   dungeon: Ganon
   exits:
@@ -95,6 +105,7 @@
   locations:
     "MQ Ganon Castle Forest Trial First Chest": "event(GANON_CASTLE_MQ_FOREST_WIND_OPEN_EYE)"
     "MQ Ganon Castle Forest Trial Second Chest": "event(GANON_CASTLE_MQ_FOREST_WIND_FROZEN_EYE)"
+
 "Ganon Castle Forest Trial Wind Room Ending Side":
   dungeon: Ganon
   exits:
@@ -106,6 +117,7 @@
     GANON_MQ_FOREST_SWITCH: "can_play_time || can_play_elegy"
   locations:
     "MQ Ganon Castle Forest Trial Second Chest": "event(GANON_CASTLE_MQ_FOREST_WIND_FROZEN_EYE)"
+
 "Ganon Castle Forest Trial Ending Room":
   dungeon: Ganon
   exits:
@@ -115,6 +127,7 @@
   locations:
     "MQ Ganon Pot Forest End 1": "true"
     "MQ Ganon Pot Forest End 2": "true"
+
 "Ganon Castle Fire Trial Entrance Ledge":
   dungeon: Ganon
   exits:
@@ -128,6 +141,7 @@
     "MQ Ganon Castle SR Fire Back-Left": "has_tunic_goron_strict"
     "MQ Ganon Castle SR Fire High Above Lava": "has_tunic_goron"
     "MQ Ganon Castle SR Fire Front-Left": "has_tunic_goron_strict"
+
 "Ganon Castle Fire Trial Ending Ledge":
   dungeon: Ganon
   exits:
@@ -139,6 +153,7 @@
     "MQ Ganon Castle SR Fire Back-Left": "longshot_anywhere && has_tunic_goron_strict" #Needs further testing if actually strict.
     "MQ Ganon Castle SR Fire High Above Lava": "longshot_anywhere && has_tunic_goron_strict" #Needs further testing if actually strict.
     "MQ Ganon Castle SR Fire Front-Left": "longshot_anywhere && has_tunic_goron_strict" #Needs further testing if actually strict.
+
 "Ganon Castle Fire Trial Ending Room":
   dungeon: Ganon
   exits:
@@ -148,6 +163,7 @@
   locations:
     "MQ Ganon Pot Fire End 1": "true"
     "MQ Ganon Pot Fire End 2": "true"
+
 "Ganon Castle Water Trial Entrance":
   dungeon: Ganon
   exits:
@@ -174,6 +190,7 @@
     "MQ Ganon Castle Red Ice Water 5": "has_blue_fire"
     "MQ Ganon Castle Red Ice Water 6": "has_blue_fire"
     "MQ Ganon Castle Red Ice Water 7": "has_blue_fire"
+
 "Ganon Castle Water Trial Entrance Room Behind Red Ice":
   dungeon: Ganon
   exits:
@@ -187,6 +204,7 @@
     "MQ Ganon Castle Red Ice Water 5": "has_blue_fire"
     "MQ Ganon Castle Red Ice Water 6": "has_blue_fire"
     "MQ Ganon Castle Red Ice Water 7": "has_blue_fire"
+
 "Ganon Castle Water Trial Silver Rupee Room":
   dungeon: Ganon
   exits:
@@ -204,6 +222,7 @@
     "MQ Ganon Castle Red Ice Block Silver Rupee Room 4": "has_blue_fire"
     "MQ Ganon Castle Red Ice Block Silver Rupee Room 5": "has_blue_fire"
     "MQ Ganon Castle Red Ice Block Silver Rupee Room 6": "has_blue_fire"
+
 "Ganon Castle Water Trial Silver Rupee Room Behind Red Ice":
   dungeon: Ganon
   exits:
@@ -226,6 +245,7 @@
   locations:
     "MQ Ganon Pot Water End 1": "true"
     "MQ Ganon Pot Water End 2": "true"
+
 "Ganon Castle Spirit Trial Entrance":
   dungeon: Ganon
   exits:
@@ -233,6 +253,7 @@
     "Ganon Castle Spirit Trial Sun Room Entrance Side": "event(GANON_MQ_SPIRIT_HAMMER_SWITCH)"
   events:
     GANON_MQ_SPIRIT_HAMMER_SWITCH: "((can_use_bow || can_use_slingshot) && soul_iron_knuckle && can_hammer) || (can_hammer && trick(OOT_HAMMER_WALLS))"
+
 "Ganon Castle Spirit Trial Sun Room Entrance Side":
   dungeon: Ganon
   exits:
@@ -242,6 +263,7 @@
     GANON_MQ_SPIRIT_CRYSTAL: "has_bombchu"
   locations:
       "MQ Ganon Castle Spirit Trial First Chest": "true"
+
 "Ganon Castle Spirit Trial Sun Room Sun Side":
   dungeon: Ganon
   exits:
@@ -259,6 +281,7 @@
     "MQ Ganon Castle Spirit Trial Back Left Sun Chest": "event(GANON_MQ_SPIRIT_ENDING_SUNS)"
     "MQ Ganon Castle Spirit Trial Front Left Sun Chest": "event(GANON_MQ_SPIRIT_ENDING_SUNS)"
     "MQ Ganon Castle Spirit Trial Gold Gauntlets Chest": "event(GANON_MQ_SPIRIT_ENDING_SUNS)"
+
 "Ganon Castle Spirit Trial Ending Room":
   dungeon: Ganon
   exits:
@@ -268,6 +291,7 @@
   locations:
     "MQ Ganon Pot Spirit End 1": "true"
     "MQ Ganon Pot Spirit End 2": "true"
+
 "Ganon Castle Shadow Trial Entrance Side":
   dungeon: Ganon
   exits:
@@ -282,6 +306,7 @@
     "MQ Ganon Castle SR Shadow Front-Right": "event(GANON_MQ_SHADOW_PROGRESSION_FROM_ENTRANCE)"
     "MQ Ganon Castle SR Shadow Front-Center": "event(GANON_MQ_SHADOW_PROGRESSION_FROM_ENTRANCE)"
     "MQ Ganon Castle Wonder Item": "event(GANON_MQ_SHADOW_BOMBFLOWER_FROM_ENTRANCE) && event(GANON_MQ_SHADOW_PROGRESSION_FROM_ENTRANCE)"
+
 "Ganon Castle Shadow Trial Middle Beamos Area 1":
   dungeon: Ganon
   exits:
@@ -297,6 +322,7 @@
     "MQ Ganon Castle Wonder Item": "event(GANON_MQ_SHADOW_BOMBFLOWER_FROM_BEAMOS_1) && (has_lens || longshot_anywhere)"
     "MQ Ganon Castle SR Shadow Front-Right": "has_lens || longshot_anywhere"
     "MQ Ganon Castle SR Shadow Front-Center": "has_lens"
+
 "Ganon Castle Shadow Trial Middle Beamos Area 2":
   dungeon: Ganon
   exits:
@@ -309,12 +335,14 @@
     "MQ Ganon Castle Shadow Trial Switch Chest": "event(GANON_MQ_SHADOW_EYE_CHEST)"
     "MQ Ganon Castle SR Shadow Back-Left": "has_lens || hookshot_anywhere"
     "MQ Ganon Castle SR Shadow Back-Center": "has_lens"
+
 "Ganon Castle Shadow Trial Ending Side":
   dungeon: Ganon
   exits:
     "Ganon Castle Shadow Trial Middle Beamos Area 2": "has_lens || hookshot_anywhere"
     "Ganon Castle Shadow Trial Ending Room": "silver_rupees_ganon_shadow"
     "Ganon Castle Shadow Trial Entrance Side": "climb_anywhere"
+
 "Ganon Castle Shadow Trial Ending Room":
   dungeon: Ganon
   exits:
@@ -324,6 +352,7 @@
   locations:
     "MQ Ganon Pot Shadow End 1": "true"
     "MQ Ganon Pot Shadow End 2": "true"
+
 "Ganon Castle Stairs":
   region: GANON_CASTLE
   exits:

--- a/data/world/oot/dungeons_mq/gerudo_training_grounds_mq.yml
+++ b/data/world/oot/dungeons_mq/gerudo_training_grounds_mq.yml
@@ -15,28 +15,33 @@
     "MQ Gerudo Training Grounds Pot 2": "true"
     "MQ Gerudo Training Grounds Pot 3": "true"
     "MQ Gerudo Training Grounds Pot 4": "true"
+
 "Gerudo Training Grounds Wallmaster":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Gerudo Training Grounds Maze Entrance Fork":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds": "true"
     "Gerudo Training Grounds Maze Left Room 1": "true"
     "Gerudo Training Grounds Maze Right Room 1": "event(GTG_MQ_LAVA_HAMMER_SWITCH)"
+
 "Gerudo Training Grounds Maze Left Room 1":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Maze Entrance Fork": "true"
     "Gerudo Training Grounds Maze Left Room 2": "true"
     "Gerudo Training Grounds Maze Left Hidden Room": "has_lens"
+
 "Gerudo Training Grounds Maze Left Hidden Room":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Maze Left Room 1": "true"
   locations:
     "MQ Gerudo Training Grounds Maze First Chest": "true"
+
 "Gerudo Training Grounds Maze Left Room 2":
   dungeon: GTG
   exits:
@@ -44,11 +49,13 @@
     "Gerudo Training Grounds Maze Left Room 3": "true"
   locations:
     "MQ Gerudo Training Grounds Maze Second Chest": "true"
+
 "Gerudo Training Grounds Maze Left Room 3":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Maze Left Room 2": "true"
     "Gerudo Training Grounds Maze Left Room 4": "true"
+
 "Gerudo Training Grounds Maze Left Room 4":
   dungeon: GTG
   exits:
@@ -56,6 +63,7 @@
     "Gerudo Training Grounds Maze Left Room 5": "small_keys_gtg(1)"
   locations:
     "MQ Gerudo Training Grounds Maze Third Chest": "true"
+
 "Gerudo Training Grounds Maze Left Room 5":
   dungeon: GTG
   exits:
@@ -63,11 +71,13 @@
     "Gerudo Training Grounds Maze Left Room 6": "small_keys_gtg(2)"
   locations:
     "MQ Gerudo Training Grounds Maze Fourth Chest": "true"
+
 "Gerudo Training Grounds Maze Left Room 6":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Maze Left Room 5": "small_keys_gtg(3)"
     "Gerudo Training Grounds Maze Center Room": "small_keys_gtg(3)"
+
 "Gerudo Training Grounds Maze Center Room":
   dungeon: GTG
   exits:
@@ -76,11 +86,13 @@
     GTG_ICE_ARROWS_SWITCH: "can_hammer"
   locations:
     "MQ Gerudo Training Grounds Maze Center Room Large Crate": "true"
+
 "Gerudo Training Grounds Maze Right Room 1":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Maze Entrance Fork": "true"
     "Gerudo Training Grounds Maze Right Room 2": "true"
+
 "Gerudo Training Grounds Maze Right Room 2":
   dungeon: GTG
   exits:
@@ -89,6 +101,7 @@
   locations:
     "MQ Gerudo Training Grounds Maze Right Side Middle Chest": "true"
     "MQ Gerudo Training Grounds Maze Right Side Right Chest": "true"
+
 "Gerudo Training Grounds Right Path First Room":
   dungeon: GTG
   exits:
@@ -99,6 +112,7 @@
   locations:
     "MQ Gerudo Training Grounds Right Side Dinolfos Chest": "event(GTG_MQ_RIGHT_FIRST_CLEAR)"
     "MQ Gerudo Training Grounds Wonder Item Dodongo Room Wall": "can_use_bow"
+
 "Gerudo Training Grounds Lava Room Near Beginning":
   dungeon: GTG
   exits:
@@ -119,6 +133,7 @@
     "MQ Gerudo Training Grounds SR Lava Front-Right": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_ENTRANCE)"
     "MQ Gerudo Training Grounds SR Lava Front-Left": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_ENTRANCE)"
     "MQ Gerudo Training Grounds SR Lava Front": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_ENTRANCE)"
+
 "Gerudo Training Grounds Lava Room Ledge Before Water Room":
   dungeon: GTG
   exits:
@@ -138,6 +153,7 @@
     "MQ Gerudo Training Grounds SR Lava Front-Right": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_WATER_SIDE)"
     "MQ Gerudo Training Grounds SR Lava Front-Left": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_WATER_SIDE)"
     "MQ Gerudo Training Grounds SR Lava Front": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_WATER_SIDE)"
+
 "Gerudo Training Grounds Lava Room Maze Ledge":
   dungeon: GTG
   exits:
@@ -157,6 +173,7 @@
     "MQ Gerudo Training Grounds SR Lava Front-Right": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_FAR)"
     "MQ Gerudo Training Grounds SR Lava Front-Left": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_FAR)"
     "MQ Gerudo Training Grounds SR Lava Front": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_FAR)"
+
 "Gerudo Training Grounds Lava Room Deep Side Ledge":
   dungeon: GTG
   exits:
@@ -176,6 +193,7 @@
     "MQ Gerudo Training Grounds SR Lava Front-Right": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_FAR)"
     "MQ Gerudo Training Grounds SR Lava Front-Left": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_FAR)"
     "MQ Gerudo Training Grounds SR Lava Front": "event(GTG_MQ_LAVA_TORCH_COMMON_PLATFORMS_FAR)"
+
 "Gerudo Training Grounds Water Room":
   dungeon: GTG
   exits:
@@ -185,6 +203,7 @@
     "MQ Gerudo Training Grounds SR Water Top-Left": "has_iron_boots && (can_swim || can_hookshot) && has_tunic_zora && has_fire"
     "MQ Gerudo Training Grounds SR Water Center": "has_iron_boots && (can_swim || longshot_anywhere) && has_tunic_zora && has_fire" #Also can fall directly onto it with irons only, but stingers can knock you away. Can add as a trick if we really want to. Or maybe arrows to kill stingers?
     "MQ Gerudo Training Grounds SR Water Bottom-Right": "has_iron_boots && (can_swim || can_hookshot) && has_tunic_zora && has_fire"
+
 "Gerudo Training Grounds Left Path First Room":
   dungeon: GTG
   events:
@@ -194,6 +213,7 @@
     "Gerudo Training Grounds Slopes": "event(GTG_IRON_KNUCKLE)"
   locations:
    "MQ Gerudo Training Grounds Left Side Iron Knuckle Chest": "event(GTG_IRON_KNUCKLE)"
+
 "Gerudo Training Grounds Slopes":
   dungeon: GTG
   exits:
@@ -213,6 +233,7 @@
     "MQ Gerudo Training Grounds Icicle Slopes 3": "break_icicle"
     "MQ Gerudo Training Grounds Icicle Slopes 4": "break_icicle"
     "MQ Gerudo Training Grounds Icicle Slopes 5": "break_icicle"
+
 "Gerudo Training Grounds Stalfos Room":
   dungeon: GTG
   exits:
@@ -225,11 +246,13 @@
     GTG_MQ_SILVER_BLOCK_PUSH: "can_lift_silver"
   locations:
     "MQ Gerudo Training Grounds Stalfos Room Chest": "event(GTG_MQ_STALFOS_CLEAR)"
+
 "Gerudo Training Grounds Stalfos Room After Silver Block":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Stalfos Room": "event(GTG_MQ_SILVER_BLOCK_PUSH)"
     "Gerudo Training Grounds Stalfos Room Side Room": "event(GTG_MQ_STALFOS_CLEAR)"
+
 "Gerudo Training Grounds Stalfos Room Side Room":
   dungeon: GTG
   exits:
@@ -238,16 +261,19 @@
     GTG_MQ_STALFOS_SIDE_CLEAR: "soul_enemy(SOUL_ENEMY_SPIKE) && soul_freezard && (can_use_sword_master || can_use_sword_razor || (has(SWORD_BIGGORON) && age_sword_adult))" #Kokiri Sword is too weak against freezards
   locations:
     "MQ Gerudo Training Grounds Silver Block Room Chest": "event(GTG_MQ_STALFOS_SIDE_CLEAR)"
+
 "Gerudo Training Grounds Stalfos Room Ledge Before Red Ice":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Stalfos Room Ledge After Red Ice": "has_blue_fire"
     "Gerudo Training Grounds Stalfos Room": "has_lens"
+
 "Gerudo Training Grounds Stalfos Room Ledge After Red Ice":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Stalfos Room Ledge Before Red Ice": "has_blue_fire || trick(OOT_PASS_COLLISION)" #Only solid on one side.
     "Gerudo Training Grounds Spinning Statue Room Upper": "event(GTG_MQ_STALFOS_CLEAR)"
+
 "Gerudo Training Grounds Spinning Statue Room Upper":
   dungeon: GTG
   exits:
@@ -255,12 +281,14 @@
     "Gerudo Training Grounds Spinning Statue Room Upper Side Door": "event(GTG_MQ_SPINNING_STATUE_CRYSTAL)"
     "Gerudo Training Grounds Spinning Statue Room Lower": "true"
     "Gerudo Training Grounds Spinning Statue Room Statue Middle": "has_hover_boots || can_longshot || hookshot_anywhere"
+
 "Gerudo Training Grounds Spinning Statue Room Upper Side Door":
   dungeon: GTG
   exits:
     "Gerudo Training Grounds Spinning Statue Room Upper": "true"
   locations:
     "MQ Gerudo Training Grounds Ice Arrows Chest": "event(GTG_ICE_ARROWS_SWITCH)"
+
 "Gerudo Training Grounds Spinning Statue Room Lower":
   dungeon: GTG
   exits:
@@ -272,6 +300,7 @@
     GTG_MQ_SPINNING_STATUE_CRYSTAL: "can_use_bow || can_use_slingshot || can_hookshot || has_explosives || can_boomerang"
   locations:
     "MQ Gerudo Training Grounds Spinning Statue Chest": "event(GTG_MQ_SPINNING_STATUE_EYES)"
+
 "Gerudo Training Grounds Spinning Statue Room Statue Middle":
   dungeon: GTG
   exits:
@@ -279,6 +308,7 @@
     "Gerudo Training Grounds Spinning Statue Room Lower": "is_adult || (has_hover_boots || climb_anywhere) || hookshot_anywhere"
   locations:
     "MQ Gerudo Training Grounds Wonder Item Eye Statue": "true"
+
 "Gerudo Training Grounds Room After Spinning Statue":
   dungeon: GTG
   exits:

--- a/data/world/oot/dungeons_mq/ice_cavern_mq.yml
+++ b/data/world/oot/dungeons_mq/ice_cavern_mq.yml
@@ -6,6 +6,7 @@
     "Ice Cavern Room After Entrance Boulder": "true"
   locations:
     "MQ Ice Cavern Pot Entrance": "true"
+
 "Ice Cavern Room After Entrance Boulder":
   dungeon: IC
   exits:
@@ -17,6 +18,7 @@
   locations:
     "MQ Ice Cavern Icicle Entrance 1": "break_icicle_ice_cavern"
     "MQ Ice Cavern Icicle Entrance 2": "break_icicle_ice_cavern"
+
 "Ice Cavern After Initial Ice Block":
   dungeon: IC
   exits:
@@ -30,6 +32,7 @@
     "MQ Ice Cavern Icicle Before Main Room 3": "break_icicle_ice_cavern"
     "MQ Ice Cavern Icicle Before Main Room 4": "break_icicle_ice_cavern"
     "MQ Ice Cavern Icicle Before Main Room 5": "break_icicle_ice_cavern"
+
 "Ice Cavern Main Room":
   dungeon: IC
   exits:
@@ -55,6 +58,7 @@
     "MQ Ice Cavern Red Ice Main Room 4": "has_blue_fire"
     "MQ Ice Cavern Red Ice Main Room 5": "has_blue_fire"
     "MQ Ice Cavern Red Ice Main Room 6": "has_blue_fire"
+
 "Ice Cavern Map Room":
   dungeon: IC
   exits:
@@ -76,6 +80,7 @@
     "MQ Ice Cavern Icicle Map Room 8": "break_icicle_ice_cavern"
     "MQ Ice Cavern Icicle Map Room 9": "break_icicle_ice_cavern"
     "MQ Ice Cavern Red Ice Map Room": "has_blue_fire"
+
 "Ice Cavern Compass Room":
   dungeon: IC
   exits:
@@ -93,6 +98,7 @@
     "MQ Ice Cavern Icicle Compass Room 3": "break_icicle_ice_cavern"
     "MQ Ice Cavern Icicle Compass Room 4": "break_icicle_ice_cavern"
     "MQ Ice Cavern Red Ice Compass Room": "has_blue_fire"
+
 "Ice Cavern Vanilla Push Block Room":
   dungeon: IC
   exits:
@@ -107,12 +113,14 @@
     "MQ Ice Cavern Red Ice Block Room 1": "has_blue_fire"
     "MQ Ice Cavern Red Ice Block Room 2": "has_blue_fire"
     "MQ Ice Cavern Red Ice Block Room 3": "has_blue_fire"
+
 "Ice Cavern Vanilla Push Block Room Scarecrow Ledge":
   dungeon: IC
   exits:
     "Ice Cavern Vanilla Push Block Room": "true"
   locations:
     "MQ Ice Cavern GS Scarecrow": "gs && can_damage_skull"
+
 "Ice Cavern Past Red Ice Before Shiek":
   dungeon: IC
   exits:
@@ -121,6 +129,7 @@
   locations:
     "MQ Ice Cavern Pot Final Corridor 1": "true"
     "MQ Ice Cavern Pot Final Corridor 2": "true"
+
 "Ice Cavern Serenade Room":
   dungeon: IC
   exits:
@@ -131,16 +140,19 @@
   locations:
     "MQ Ice Cavern Iron Boots": "event(ICE_MQ_FINAL_ROOM_CLEAR)"
     "MQ Ice Cavern Sheik Song": "event(ICE_MQ_FINAL_ROOM_CLEAR) && soul_npc(SOUL_NPC_SHEIK)"
+
 "Ice Cavern Serenade Room Inside Pit of Water":
   dungeon: IC
   exits:
     "Ice Cavern Serenade Room": "can_swim" #Might be able to use irons + hookshot anywhere too, rather than needing to float.
     "Ice Cavern Ledge After Shiek Water Section": "has_iron_boots"
+
 "Ice Cavern Ledge After Shiek Water Section":
   dungeon: IC
   exits:
     "Ice Cavern Serenade Room Inside Pit of Water": "has_iron_boots"
     "Ice Cavern Ledge After Shiek": "can_swim_or_sink"
+
 "Ice Cavern Ledge After Shiek":
   dungeon: IC
   exits:

--- a/data/world/oot/dungeons_mq/jabu_jabu_mq.yml
+++ b/data/world/oot/dungeons_mq/jabu_jabu_mq.yml
@@ -15,6 +15,7 @@
     "MQ Jabu-Jabu Grass Entrance 2": "can_cut_grass"
     "MQ Jabu-Jabu Wonder Item Entrance Left Cow": "can_use_slingshot && (soul_cow || trick(OOT_MQ_JABU_WITHOUT_COW_SOUL))"
     "MQ Jabu-Jabu Wonder Item Entrance Right Cow": "can_use_slingshot && (soul_cow || trick(OOT_MQ_JABU_WITHOUT_COW_SOUL))"
+
 "Jabu-Jabu Main Elevator Room Upper":
   dungeon: JJ
   exits:
@@ -28,6 +29,7 @@
   locations:
     "MQ Jabu-Jabu Heart 1": "true"
     "MQ Jabu-Jabu Heart 2": "true"
+
 "Jabu-Jabu Main Elevator Room Lower":
   dungeon: JJ
   exits:
@@ -42,6 +44,7 @@
     "MQ Jabu-Jabu Rupee Bottom": "has_iron_boots" #Any requirement with swimming is better suited for the other region where these checks are.
     "MQ Jabu-Jabu Rupee Middle": "has_iron_boots" #Any requirement with swimming is better suited for the other region where these checks are.
     "MQ Jabu-Jabu Rupee Top": "has_iron_boots" #Any requirement with swimming is better suited for the other region where these checks are.
+
 "Jabu-Jabu Main Elevator Room Lower Switch Alcove Ledge":
   dungeon: JJ
   exits:
@@ -56,6 +59,7 @@
     "MQ Jabu-Jabu Rupee Bottom": "(can_swim && can_dive_big) || can_boomerang"
     "MQ Jabu-Jabu Rupee Middle": "(can_swim && can_dive_small) || can_boomerang"
     "MQ Jabu-Jabu Rupee Top": "(can_swim && (is_child || can_dive_small)) || can_boomerang"
+
 "Jabu-Jabu Main Elevator Room Ledge Before Pre-Boss":
   dungeon: JJ
   exits:
@@ -64,6 +68,7 @@
     "Jabu-Jabu Pre-Boss Room": "event(JABU_TENTACLE_RED)"
   locations:
     "MQ Jabu-Jabu Second Room 1F Chest": "can_use_slingshot"
+
 "Jabu-Jabu Vanilla Ruto Falling Room":
   dungeon: JJ
   exits:
@@ -76,11 +81,13 @@
   locations:
     "MQ Jabu-Jabu Grass Main Room Top 1": "can_cut_grass && has_explosives_or_hammer"
     "MQ Jabu-Jabu Grass Main Room Top 2": "can_cut_grass && has_explosives_or_hammer"
+
 "Jabu-Jabu Vanilla Ruto Falling Room After Wiggling Thing":
   dungeon: JJ
   exits:
     "Jabu-Jabu Vanilla Ruto Falling Room": "can_boomerang"
     "Jabu-Jabu Back Forked Paths": "event(JABU_MQ_BACK_UNLOCK)"
+
 "Jabu-Jabu Ruto Section Bottom Floor":
   dungeon: JJ
   exits:
@@ -94,6 +101,7 @@
     "MQ Jabu-Jabu Grass Main Room Bottom 1": "can_cut_grass"
     "MQ Jabu-Jabu Grass Main Room Bottom 2": "can_cut_grass"
     "MQ Jabu-Jabu Grass Main Room Bottom 3": "can_cut_grass"
+
 "Jabu Jabu Basement Loop to Main Elevator West Side":
   dungeon: JJ
   exits:
@@ -104,6 +112,7 @@
   locations:
     "MQ Jabu-Jabu Boomerang Chest": "event(JABU_MQ_WATER_SPOUTS)"
     "MQ Jabu-Jabu GS SoT Block": "gs && can_play_time && can_damage_skull"
+
 "Jabu Jabu Basement Loop to Main Elevator East Side":
   dungeon: JJ
   exits:
@@ -118,6 +127,7 @@
     "MQ Jabu-Jabu Grass Boomerang Room": "can_cut_grass"
     "MQ Jabu-Jabu GS SoT Block": "gs && can_play_time && can_damage_skull"
     "MQ Jabu-Jabu Boomerang Chest": "event(JABU_MQ_WATER_SPOUTS)"
+
 "Jabu-Jabu Basement Ledge Before Big Octo":
   dungeon: JJ
   exits:
@@ -130,11 +140,13 @@
     "MQ Jabu-Jabu Wonder Item Basement Left Cow 1": "can_use_slingshot"
     "MQ Jabu-Jabu Wonder Item Basement Left Cow 2": "can_use_slingshot"
     "MQ Jabu-Jabu Wonder Item Basement Left Cow 3": "can_use_slingshot"
+
 "Jabu-Jabu Basement Ledge Before Big Octo After Green Tentacle":
   dungeon: JJ
   exits:
     "Jabu-Jabu Basement Ledge Before Big Octo": "event(JABU_TENTACLE_GREEN)" #This tentacle can block in door rando, so it needs its own region.
     "Jabu-Jabu Big Octo Room": "true"
+
 "Jabu-Jabu Big Octo Room":
   dungeon: JJ
   exits:
@@ -142,6 +154,7 @@
     "Jabu-Jabu Above Big Octo Fight": "event(JABU_BIG_OCTO)"
   events:
     JABU_BIG_OCTO: "soul_octorok && (can_use_sticks || has_weapon) && soul_ruto"
+
 "Jabu-Jabu Above Big Octo Fight":
   dungeon: JJ
   exits:
@@ -150,6 +163,7 @@
     "MQ Jabu-Jabu Grass Big Octo Top 1": "can_cut_grass"
     "MQ Jabu-Jabu Grass Big Octo Top 2": "can_cut_grass"
     "MQ Jabu-Jabu Wonder Item After Big Octo": "can_use_slingshot"
+
 "Jabu-Jabu Room After Above Big Octo":
   dungeon: JJ
   exits:
@@ -163,6 +177,7 @@
     "MQ Jabu-Jabu Wonder Item Platforms Cow": "event(MQ_JABU_AFTER_ABOVE_BIG_OCTO_SPAWN_COW_AND_CRATES)"
     "MQ Jabu-Jabu Room After Above Big Octo Small Crate 1": "event(MQ_JABU_AFTER_ABOVE_BIG_OCTO_SPAWN_COW_AND_CRATES)"
     "MQ Jabu-Jabu Room After Above Big Octo Small Crate 2": "event(MQ_JABU_AFTER_ABOVE_BIG_OCTO_SPAWN_COW_AND_CRATES)"
+
 "Jabu-Jabu Main Elevator Room High Ledge":
   dungeon: JJ
   exits:
@@ -171,6 +186,7 @@
     "Jabu-Jabu Main Elevator Room Lower": "true"
   events:
     JABU_MQ_LOWER_BIG_OCTO_PLATFORM: "true"
+
 "Jabu-Jabu Back Forked Paths":
   dungeon: JJ
   exits:
@@ -186,6 +202,7 @@
   locations:
     "MQ Jabu-Jabu Back Forked Paths Main Room Small Crate 1": "true"
     "MQ Jabu-Jabu Back Forked Paths Main Room Small Crate 2": "true"
+
 "Jabu-Jabu Back Forked Paths Center After Rocks":
   dungeon: JJ
   exits:
@@ -193,12 +210,14 @@
     "Jabu-Jabu Back Forked Paths Center Room": "event(JABU_MQ_BACK_CENTER_SWITCH)"
   events:
     JABU_MQ_BACK_CENTER_SWITCH: "can_play_elegy" #Event is split up because of the rocks.
+
 "Jabu-Jabu Back Forked Paths Center Room":
   dungeon: JJ
   exits:
     "Jabu-Jabu Back Forked Paths Center After Rocks": "true"
   events:
     JABU_TENTACLE_RED: "can_boomerang && soul_enemy(SOUL_ENEMY_PARASITE)"
+
 "Jabu-Jabu Back Forked Paths Right 1":
   dungeon: JJ
   exits:
@@ -219,29 +238,34 @@
     "MQ Jabu-Jabu Wonder Item Falling Like-Likes Explosion 1": "has_explosives"
     "MQ Jabu-Jabu Wonder Item Falling Like-Likes Explosion 2": "has_explosives"
     "MQ Jabu-Jabu Wonder Item Falling Like-Likes Explosion 3": "has_explosives"
+
 "Jabu-Jabu Back Forked Paths After Right 2 Web":
   dungeon: JJ
   exits:
     "Jabu-Jabu Back Forked Paths": "true" #One-sided collision on the web
     "Jabu-Jabu Back Forked Paths Right 2": "true"
+
 "Jabu-Jabu Back Forked Paths Right 2":
   dungeon: JJ
   exits:
     "Jabu-Jabu Back Forked Paths After Right 2 Web": "true"
   events:
     JABU_TENTACLE_BLUE: "can_boomerang && soul_enemy(SOUL_ENEMY_PARASITE)"
+
 "Jabu-Jabu Back Forked Paths Left 1":
   dungeon: JJ
   exits:
     "Jabu-Jabu Back Forked Paths": "true"
   events:
     JABU_TENTACLE_GREEN: "can_boomerang && soul_enemy(SOUL_ENEMY_PARASITE)"
+
 "Jabu-Jabu Back Forked Paths Left 2":
   dungeon: JJ
   exits:
     "Jabu-Jabu Back Forked Paths": "true"
   locations:
     "MQ Jabu-Jabu GS Back": "gs && ((climb_anywhere && (can_hammer || can_use_mask_blast)) || (has_explosives && can_collect_distance))"
+
 "Jabu-Jabu Basement Side Room Entrance Side":
   dungeon: JJ
   exits:
@@ -252,6 +276,7 @@
     JABU_MQ_BASEMENT_SIDE_BUTTON: "can_swim || can_dive_small" #Listed here for action shuffle
   locations:
     "MQ Jabu-Jabu GS Basement Side Room": "gs && has_fire_arrows && can_longshot"
+
 "Jabu-Jabu Basement Side Room GS Side":
   dungeon: JJ
   exits:
@@ -261,6 +286,7 @@
     JABU_MQ_BASEMENT_SIDE_BUTTON: "can_swim || can_dive_small" #Listed here for action shuffle
   locations:
     "MQ Jabu-Jabu GS Basement Side Room": "gs && (can_collect_distance || (climb_anywhere && can_damage_skull))"
+
 "Jabu-Jabu Pre-Boss Room":
   dungeon: JJ
   exits:

--- a/data/world/oot/dungeons_mq/shadow_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/shadow_temple_mq.yml
@@ -4,11 +4,13 @@
     "GLOBAL": "true"
     "Graveyard Upper": "true"
     "Shadow Temple Entrance": "true"
+
 "Shadow Temple Entrance":
   dungeon: Shadow
   exits:
     "Shadow Temple": "true"
     "Shadow Temple Truth Spinner": "has_lens && (can_hookshot || has_hover_boots || glitch_megaflip || climb_anywhere)"
+
 "Shadow Temple Truth Spinner":
   dungeon: Shadow
   exits:
@@ -26,16 +28,19 @@
     "MQ Shadow Temple Truth Spinner Room Small Crate 2": "true"
     "MQ Shadow Temple Truth Spinner Room Small Crate 3": "true"
     "MQ Shadow Temple Truth Spinner Room Small Crate 4": "true"
+
 "Shadow Temple Spinner Room Hallway to Textured Maze":
   dungeon: Shadow
   exits:
     "Shadow Temple Truth Spinner": "(has_lens && has_explosives) || trick(OOT_PASS_COLLISION)"
     "Shadow Temple Textured Maze Room Lens Alcove to Spinner": "small_keys_shadow(6)"
+
 "Shadow Temple Textured Maze Room Lens Alcove to Spinner":
   dungeon: Shadow
   exits:
     "Shadow Temple Spinner Room Hallway to Textured Maze": "small_keys_shadow(6)"
     "Shadow Temple Textured Maze First Half": "has_lens"
+
 "Shadow Temple Textured Maze First Half":
   dungeon: Shadow
   exits:
@@ -47,11 +52,13 @@
     "MQ Shadow Temple Pot Entrance Maze 2": "true"
     "MQ Shadow Temple Flying Pot Entrance Maze 1": "soul_flying_pot"
     "MQ Shadow Temple Flying Pot Entrance Maze 2": "soul_flying_pot"
+
 "Shadow Temple Textured Maze Room Lens Alcove to Side Room":
   dungeon: Shadow
   exits:
     "Shadow Temple Textured Maze First Half": "has_lens"
     "Shadow Temple Textured Maze First Half Side Room": "true"
+
 "Shadow Temple Textured Maze First Half Side Room":
   dungeon: Shadow
   exits:
@@ -62,6 +69,7 @@
     "MQ Shadow Temple Compass Chest": "event(SHADOW_MQ_TEXTURED_MAZE_SIDE_ROOM_CLEAR)"
     "MQ Shadow Temple Pot Compass Room 1": "can_use_din || can_play_sun" #It would be too unfair to get around the Redeads otherwise
     "MQ Shadow Temple Pot Compass Room 2": "can_use_din || can_play_sun" #It would be too unfair to get around the Redeads otherwise
+
 "Shadow Temple Textured Maze Second Half":
   dungeon: Shadow
   exits:
@@ -72,11 +80,13 @@
   locations:
     "MQ Shadow Temple Flying Pot Entrance Maze 3": "soul_flying_pot"
     "MQ Shadow Temple Flying Pot Entrance Maze 4": "soul_flying_pot"
+
 "Shadow Temple Textured Maze Room Lens Alcove to Dead Hand Room":
   dungeon: Shadow
   exits:
     "Shadow Temple Textured Maze Second Half": "has_lens && event(SHADOW_MQ_TEXTURED_MAZE_LOWER_ICE_BLOCK)"
     "Shadow Temple Dead Hand Room": "true"
+
 "Shadow Temple Dead Hand Room":
   dungeon: Shadow
   exits:
@@ -85,6 +95,7 @@
     SHADOW_MQ_TEXTURED_MAZE_DEAD_HAND_ROOM_CLEAR: "soul_enemy(SOUL_ENEMY_DEAD_HAND) && (has_weapon || (can_use_sticks && trick(OOT_DEAD_HAND_STICKS)))"
   locations:
     "MQ Shadow Temple Hover Boots Chest": "event(SHADOW_MQ_TEXTURED_MAZE_DEAD_HAND_ROOM_CLEAR)"
+
 "Shadow Temple Spinner Room Platform Before First Beamos Fork":
   dungeon: Shadow
   exits:
@@ -92,6 +103,7 @@
     "Shadow Temple First Beamos Fork": "event(SHADOW_MQ_TRUTH_SPINNER)"
   events:
     SHADOW_MQ_SPINNER_ROOM_ICE_PLATFORM: "has_fire"
+
 "Shadow Temple First Beamos Fork":
   dungeon: Shadow
   exits:
@@ -103,11 +115,13 @@
     #SHADOW_MQ_SPINNER_ROOM_ICE_PLATFORM: "can_use_din" #Can light flames with Din's right after the gate. TODO make it a trick.
   locations:
     "MQ Shadow Temple Beamos Big Fairy": "can_play_storms"
+
 "Shadow Temple First Beamos Fork Room Lens Alcove to Gibdo Room":
   dungeon: Shadow
   exits:
     "Shadow Temple First Beamos Fork": "has_lens"
     "Shadow Temple First Beamos Fork Gibdo Room": "true"
+
 "Shadow Temple First Beamos Fork Gibdo Room":
   dungeon: Shadow
   exits:
@@ -116,11 +130,13 @@
     SHADOW_MQ_FIRST_BEAMOS_FORK_GIBDOS_CLEAR: "soul_redead_gibdo && (has_weapon || can_use_sticks || can_use_din)"
   locations:
     "MQ Shadow Temple First Gibdos Chest": "event(SHADOW_MQ_FIRST_BEAMOS_FORK_GIBDOS_CLEAR)"
+
 "Shadow Temple First Beamos Fork Room Lens Alcove to Scythe and Shortcut Room":
   dungeon: Shadow
   exits:
     "Shadow Temple First Beamos Fork": "has_lens"
     "Shadow Temple Scythe Room": "true"
+
 "Shadow Temple Scythe Room":
   dungeon: Shadow
   exits:
@@ -135,6 +151,7 @@
     "MQ Shadow Temple SR Scythe 4": "true"
     "MQ Shadow Temple SR Scythe 5": "true"
     "MQ Shadow Temple Map Chest": "silver_rupees_shadow_scythe"
+
 "Shadow Temple Enclosed Shortcut Area":
   dungeon: Shadow
   exits:
@@ -143,28 +160,33 @@
     "Shadow Temple Area Above Shortcut Enclosure": "climb_anywhere && trick(OOT_SHADOW_BOAT_EARLY)"
   locations:
     "MQ Shadow Temple Boat Passage Chest": "has_lens"
+
 "Shadow Temple First Beamos Fork Room Solid Wall Alcove to Guillotine Hallway":
   dungeon: Shadow
   exits:
     "Shadow Temple First Beamos Fork": "has_explosives || trick(OOT_PASS_COLLISION)"
     "Shadow Temple Upper Guillotine Hallway Before Upper Huge Pit": "small_keys_shadow(2)"
+
 "Shadow Temple Upper Guillotine Hallway Before Upper Huge Pit":
   dungeon: Shadow
   exits:
     "Shadow Temple First Beamos Fork Room Solid Wall Alcove to Guillotine Hallway": "small_keys_shadow(2)"
     "Shadow Temple Lower Guillotine Hallway Before Upper Huge Pit": "true" #Can avoid all beamos and skultullas.
+
 "Shadow Temple Lower Guillotine Hallway Before Upper Huge Pit":
   dungeon: Shadow
   exits:
     "Shadow Temple Upper Guillotine Hallway Before Upper Huge Pit": "can_hookshot || climb_anywhere"
     "Shadow Temple Upper Huge Pit Guillotine Section Before Drop": "true" #Can avoid all beamos and skultullas.
     "Shadow Temple Lower Huge Pit Ledge Before Invisible Spike Floors": "climb_anywhere"
+
 "Shadow Temple Upper Huge Pit Guillotine Section Before Drop":
   dungeon: Shadow
   exits:
     "Shadow Temple Lower Guillotine Hallway Before Upper Huge Pit": "true"
     "Shadow Temple Upper Huge Pit After Drop": "true"
     "Shadow Temple Lower Huge Pit": "longshot_anywhere" #Can stand on the hookshot target and then make it.
+
 "Shadow Temple Upper Huge Pit After Drop":
   dungeon: Shadow
   exits:
@@ -173,11 +195,13 @@
     "Shadow Temple Lower Huge Pit": "event(SHADOW_MQ_UPPER_HUGE_PIT_FROZEN_EYE) || has_hover_boots || hookshot_anywhere" #Child can *easily* reach with hovers+fast bunny hood without the platforms. Child can also reach with just hovers but its tight. Adult reaches with hovers only no problems.
   events:
     SHADOW_MQ_UPPER_HUGE_PIT_FROZEN_EYE: "has_fire" #If HSW (OoT) is added as a bottle content, maybe can work here because it's below you.
+
 "Shadow Temple Upper Huge Pit East Ledge Before Invisible Scythe Room":
   dungeon: Shadow
   exits:
     "Shadow Temple Upper Huge Pit After Drop": "has_lens"
     "Shadow Temple Invisible Scythe Room": "true"
+
 "Shadow Temple Invisible Scythe Room":
   dungeon: Shadow
   exits:
@@ -197,6 +221,7 @@
     "MQ Shadow Temple Second Silver Rupee Invisible Chest": "silver_rupees_shadow_blades && has_lens"
     "MQ Shadow Temple Heart Invisible Blades 1": "(can_play_time && is_adult) || hookshot_anywhere || (is_child && climb_anywhere) || can_boomerang" #TODO: Add trick for Like-Like boosting onto the block.
     "MQ Shadow Temple Heart Invisible Blades 2": "(can_play_time && is_adult) || hookshot_anywhere || (is_child && climb_anywhere) || can_boomerang" #TODO: Add trick for Like-Like boosting onto the block.
+
 "Shadow Temple Lower Huge Pit":
   dungeon: Shadow
   exits:
@@ -213,6 +238,7 @@
     "MQ Shadow Temple SR Pit Midair High": "can_longshot"
     "MQ Shadow Temple SR Pit Right": "true"
     "MQ Shadow Temple SR Pit Front": "true"
+
 "Shadow Temple Falling Spikes Room Entrance":
   dungeon: Shadow
   exits:
@@ -229,12 +255,14 @@
     "MQ Shadow Temple Pot Guillotines Room Upper 1": "(has_lens && has_goron_bracelet && is_adult) || climb_anywhere || hookshot_anywhere"
     "MQ Shadow Temple Pot Guillotines Room Upper 2": "(has_lens && has_goron_bracelet && is_adult) || climb_anywhere || hookshot_anywhere"
     "MQ Shadow Temple Guillotines Room Big Fairy": "can_play_storms" #Where even is this?
+
 "Shadow Temple Lower Huge Pit Ledge Before Invisible Spike Floors":
   dungeon: Shadow
   exits:
     "Shadow Temple Lower Huge Pit": "has_lens && (has_hover_boots || hookshot_anywhere)"
     "Shadow Temple Invisible Spike Floors Room": "small_keys_shadow(3)"
     "Shadow Temple Lower Guillotine Hallway Before Upper Huge Pit": "climb_anywhere"
+
 "Shadow Temple Invisible Spike Floors Room":
   dungeon: Shadow
   exits: #Possibly add the ice platform as a region.
@@ -256,6 +284,7 @@
     "MQ Shadow Temple SR Spikes East Ground": "true"
     "MQ Shadow Temple SR Spikes Northeast Wall": "hookshot_anywhere || (has_lens && can_longshot)" #Can angle it and longshot the ceiling target. TODO: Northeast Wall - Climb anywhere or Hookshot for adult and longshot for child, and the silver rupees (jump from the platforms above the door)
     "MQ Shadow Temple SR Spikes East Wall": "can_hookshot || climb_anywhere"
+
 "Shadow Temple Dual Staircase Stalfos Room":
   dungeon: Shadow
   exits:
@@ -264,6 +293,7 @@
     SHADOW_MQ_DUAL_STAIRCASE_STALFOS_CLEAR: "soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon"
   locations:
     "MQ Shadow Temple Stalfos Room Chest": "event(SHADOW_MQ_DUAL_STAIRCASE_STALFOS_CLEAR)"
+
 "Shadow Temple Invisible Spike Floors Room Upper Ledge Before Door":
   dungeon: Shadow
   exits: #Possibly add the ice platform as a region.
@@ -275,22 +305,26 @@
     "MQ Shadow Temple SR Spikes Center Midair": "can_hookshot"
     "MQ Shadow Temple SR Spikes South Midair": "can_hookshot && event(SHADOW_MQ_INVISIBLE_SPIKE_FLOORS_ICE_PLATFORMS)"
     "MQ Shadow Temple SR Spikes Northeast Wall": "has_hover_boots || can_jump_slash || glitch_megaflip"
+
 "Shadow Temple Wind Tunnel First Part":
   dungeon: Shadow
   exits:
     "Shadow Temple Invisible Spike Floors Room Upper Ledge Before Door": "small_keys_shadow(4)"
     "Shadow Temple Wind Tunnel After Pit Before Drop": "get_past_skultullas && (has_hover_boots || hookshot_anywhere || climb_anywhere)" #Need to get past Skultulla and the pit
+
 "Shadow Temple Wind Tunnel After Pit Before Drop":
   dungeon: Shadow
   exits:
     "Shadow Temple Wind Tunnel First Part": "true" #Can use the wind to jump across and the other wind to get past the skultulla.
     "Shadow Temple Wind Tunnel After Drop": "true"
+
 "Shadow Temple Wind Tunnel After Drop":
   dungeon: Shadow
   exits:
     "Shadow Temple Wind Tunnel After Pit Before Drop": "can_hookshot || climb_anywhere"
     "Shadow Temple Wind Tunnel Hint Room": "true"
     "Shadow Temple Wind Tunnel Lens Alcove": "has_lens" #Adult can just make it with a roll jump, and the fan pushes child.
+
 "Shadow Temple Wind Tunnel Hint Room":
   dungeon: Shadow
   exits:
@@ -301,11 +335,13 @@
     "MQ Shadow Temple Wind Hint Chest": "event(SHADOW_MQ_WIND_TUNNEL_HINT_ROOM_REDEADS_CLEAR)"
     "MQ Shadow Temple GS Wind Hint": "gs && collect_gs_on_walls"
     "MQ Shadow Temple Big Fairy After Wind": "can_play_sun"
+
 "Shadow Temple Wind Tunnel Lens Alcove":
   dungeon: Shadow
   exits:
     "Shadow Temple Wind Tunnel After Drop": "has_lens && (is_adult || has_hover_boots || hookshot_anywhere || climb_anywhere)" #Can use climb anywhere to climb onto the fan next to the alcove then jump to the center area.
     "Shadow Temple After Wind Tunnel Gibdos Room": "true"
+
 "Shadow Temple After Wind Tunnel Gibdos Room":
   dungeon: Shadow
   exits:
@@ -321,6 +357,7 @@
     "MQ Shadow Temple Pot Room Before Boat 2": "true" #Gibdos very easy to avoid.
     "MQ Shadow Temple Flying Pot Room Before Boat 1": "soul_flying_pot" #Gibdos very easy to avoid.
     "MQ Shadow Temple Flying Pot Room Before Boat 2": "soul_flying_pot" #Gibdos very easy to avoid.
+
 "Shadow Temple Area Before Boat Ride":
   dungeon: Shadow
   exits:
@@ -331,6 +368,7 @@
     "Shadow Temple On The Boat": "hookshot_anywhere || climb_anywhere" #Climb Anywhere works on the wheel. TODO: Add as trick - "Adult can jump onto the wheel and climb from there."
   events:
     SHADOW_MQ_SHORTCUT_BLOCK_PUSHED: "has_goron_bracelet"
+
 "Shadow Temple Area Above Shortcut Enclosure":
   dungeon: Shadow
   exits:
@@ -340,6 +378,7 @@
   locations:
     "MQ Shadow Temple Heart Shortcut 1": "true"
     "MQ Shadow Temple Heart Shortcut 2": "true"
+
 "Shadow Temple Boarding Boat Landing Area":
   dungeon: Shadow
   exits:
@@ -347,6 +386,7 @@
     "Shadow Temple On The Boat": "true"
     "Shadow Temple Area Above Shortcut Enclosure": "scarecrow_longshot || longshot_anywhere"
     #"Shadow Temple Area After Boat Initial Landing": "false" #Maybe with bomb hovering glitches later.
+
 "Shadow Temple On The Boat": #Made its own region for the Stalfos.
   dungeon: Shadow
   exits:
@@ -356,6 +396,7 @@
     "Shadow Temple Area After Boat Initial Landing": "event(SHADOW_MQ_ACTIVATE_BOAT_RIDE)"
   events:
     SHADOW_MQ_ACTIVATE_BOAT_RIDE: "song_event(0x0c)"
+
 "Shadow Temple Area After Boat Initial Landing":
   dungeon: Shadow
   exits:
@@ -370,6 +411,7 @@
     "MQ Shadow Temple GS After Boat": "gs && (can_hookshot || can_use_bow || can_use_slingshot || can_use_din || has_explosives || (can_boomerang && event(SHADOW_MQ_AFTER_BOAT_BRIDGE_FALL)))" #Can fall to skultulla after killing it. The angle is a little tricky though, but totally doable. Boomerang, though, is possible without the bridge but should be a trick. TODO: trick: boomerang no bridge
     "MQ Shadow Temple Pot After Boat Before Bridge 1": "true"
     "MQ Shadow Temple Pot After Boat Before Bridge 2": "true"
+
 "Shadow Temple Area After Boat After Bridge":
   dungeon: Shadow
   exits:
@@ -384,6 +426,7 @@
     "MQ Shadow Temple Pot After Boat After Bridge 1": "true"
     "MQ Shadow Temple Pot After Boat After Bridge 2": "true"
     "MQ Shadow Temple Heart Pre-Boss Lower": "is_adult || hookshot_anywhere || climb_anywhere || (can_hookshot && event(SHADOW_MQ_AFTER_BOAT_AFTER_BRIDGE_EYE_SWITCH))" #Child can jump back onto the time block after hookshotting the target.
+
 "Shadow Temple Area After Boat After Bridge High Ledge":
   dungeon: Shadow
   exits:
@@ -394,11 +437,13 @@
   locations:
     "MQ Shadow Temple Heart Pre-Boss Upper 1": "true"
     "MQ Shadow Temple Heart Pre-Boss Upper 2": "true"
+
 "Shadow Temple Invisible Wall Maze Corridor To After Boat":
   dungeon: Shadow
   exits:
     "Shadow Temple Area After Boat Initial Landing": "true"
     "Shadow Temple Invisible Wall Maze Navigation": "has_lens"
+
 "Shadow Temple Invisible Wall Maze Navigation":
   dungeon: Shadow
   exits:
@@ -406,11 +451,13 @@
     "Shadow Temple Invisible Wall Maze Corridor To Dead Hand Bomb Flower Room": "has_lens"
     "Shadow Temple Invisible Wall Maze Corridor To Triple Spinning Pots Room": "has_lens"
     "Shadow Temple Invisible Wall Maze Corridor To Crushing Walls Room": "has_lens"
+
 "Shadow Temple Invisible Wall Maze Corridor To Dead Hand Bomb Flower Room":
   dungeon: Shadow
   exits:
     "Shadow Temple Invisible Wall Maze Navigation": "has_lens"
     "Shadow Temple Invisible Wall Maze Dead Hand Bomb Flower Room": "true"
+
 "Shadow Temple Invisible Wall Maze Dead Hand Bomb Flower Room":
   dungeon: Shadow
   exits:
@@ -421,11 +468,13 @@
     "MQ Shadow Temple Hidden Dead Hand Chest": "event(SHADOW_MQ_INVISIBLE_WALL_MAZE_DEAD_HAND_CLEAR)"
     "MQ Shadow Temple Pot Bomb Flowers Room 1": "true"
     "MQ Shadow Temple Pot Bomb Flowers Room 2": "true"
+
 "Shadow Temple Invisible Wall Maze Corridor To Triple Spinning Pots Room":
   dungeon: Shadow
   exits:
     "Shadow Temple Invisible Wall Maze Navigation": "has_lens"
     "Shadow Temple Invisible Wall Maze Triple Spinning Pots Room": "true"
+
 "Shadow Temple Invisible Wall Maze Triple Spinning Pots Room":
   dungeon: Shadow
   exits:
@@ -433,11 +482,13 @@
   locations:
     "MQ Shadow Temple Triple Pot Key": "true" #Literally in the open, don't need to blow anything up.
     "MQ Shadow Temple Wonder Item": "can_use_bow"
+
 "Shadow Temple Invisible Wall Maze Corridor To Crushing Walls Room":
   dungeon: Shadow
   exits:
     "Shadow Temple Invisible Wall Maze Navigation": "has_lens"
     "Shadow Temple Invisible Wall Maze Crushing Walls Room": "small_keys_shadow(6)"
+
 "Shadow Temple Invisible Wall Maze Crushing Walls Room":
   dungeon: Shadow
   exits:
@@ -448,6 +499,7 @@
     "MQ Shadow Temple Crushing Wall Left Chest": "event(SHADOW_MQ_CRUSHING_WALLS_BURNT)"
     "MQ Shadow Temple Boss Key Chest": "event(SHADOW_MQ_CRUSHING_WALLS_BURNT)"
     "MQ Shadow Temple Pot Boss Key Room": "true"
+
 "Shadow Temple Pre-Boss Room":
   dungeon: Shadow
   exits:
@@ -455,6 +507,7 @@
     "Shadow Temple Pre-Boss": "has_lens && (has_hover_boots || climb_anywhere || hookshot_anywhere || glitch_megaflip)"
   locations:
     "MQ Shadow Temple GS Pre-Boss": "gs && has_lens && (hookshot_anywhere || glitch_megaflip || ((climb_anywhere || has_hover_boots) && (has_ranged_weapon || has_explosives || can_use_din)))" #Can fall down onto it after killing it.
+
 "Shadow Temple Pre-Boss":
   dungeon: Shadow
   exits:

--- a/data/world/oot/dungeons_mq/spirit_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/spirit_temple_mq.yml
@@ -24,18 +24,22 @@
     "MQ Spirit Temple Pot Entrance 2": "true"
     "MQ Spirit Temple Pot Entrance 3": "true"
     "MQ Spirit Temple Pot Entrance 4": "true"
+
 "Spirit Temple Wallmaster Child Sun":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Spirit Temple Wallmaster Adult Climb":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Spirit Temple Wallmaster Statue":
   region: BUFFER_DELAYED
   exits:
     "VOID": "true"
+
 "Spirit Temple Child Side":
   dungeon: Spirit
   exits:
@@ -55,6 +59,7 @@
     "MQ Spirit Temple Pot Child Back 4": "soul_enemy(SOUL_ENEMY_TORCH_SLUG) && (!setting(restoreBrokenActors) || soul_keese) && soul_redead_gibdo && soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon && has_bombchu && can_use_slingshot"
     "MQ Spirit Temple Heart 1": "can_hit_triggers_distance"
     "MQ Spirit Temple Heart 2": "can_hit_triggers_distance"
+
 "Spirit Temple Child Upper":
 #All paths into this room guarantee explosives.
   dungeon: Spirit
@@ -66,6 +71,7 @@
     "MQ Spirit Temple Child Upper Ground Chest": "soul_like_like && soul_beamos && soul_enemy(SOUL_ENEMY_BABY_DODONGO) && has_explosives" #Explosives are enough for every enemy in this room
     "MQ Spirit Temple Child Upper Ledge Chest": "can_hookshot"
     "MQ Spirit Temple Pot Child Climb": "true"
+
 "Spirit Temple Statue":
   dungeon: Spirit
   exits:
@@ -94,6 +100,7 @@
     "MQ Spirit Temple Giant Statue Room Large Crate 1": "true"
     "MQ Spirit Temple Giant Statue Room Large Crate 2": "true"
     "MQ Spirit Temple Giant Statue Room Small Crate": "true" #Can backflip onto block with playing Song of Time.
+
 "Spirit Temple Sun Block Room":
   dungeon: Spirit
   exits:
@@ -105,12 +112,14 @@
     "MQ Spirit Temple GS Sun Block Room": "gs && is_adult"
     "MQ Spirit Temple Pot Child Sun Room 1": "true"
     "MQ Spirit Temple Pot Child Sun Room 2": "true"
+
 "Spirit Temple Child Hand":
   dungeon: Spirit
   exits:
     "Desert Colossus": "true"
   locations:
     "Spirit Temple Silver Gauntlets": "true"
+
 "Spirit Temple Adult Lower":
   dungeon: Spirit
   locations:
@@ -123,6 +132,7 @@
     "MQ Spirit Temple SR Lobby After Water Near Door": "true"
     "MQ Spirit Temple Pot Adult Climb 1": "true"
     "MQ Spirit Temple Pot Adult Climb 2": "true"
+
 "Spirit Temple Adult Upper":
   dungeon: Spirit
   exits:
@@ -131,6 +141,7 @@
   locations:
     "MQ Spirit Temple Beamos Room Chest": "soul_beamos"
     "MQ Spirit Temple Beamos Room Small Crate": "can_play_time" #Hook+Climb Anywhere can get ontop of time block over cieling to reach crate.
+
 "Spirit Temple Adult Upper 2":
   dungeon: Spirit
   exits:
@@ -142,6 +153,7 @@
     "Spirit Temple Mirror Shield": "has_lens && soul_iron_knuckle && soul_floormaster"
     "MQ Spirit Temple Wonder Item Chest Hammer": "can_hammer"
     "MQ Spirit Temple Wonder Item Chest Slash": "can_use_sword_or_sticks"
+
 "Spirit Temple Adult Hand":
   dungeon: Spirit
   exits:
@@ -149,6 +161,7 @@
     "Spirit Temple Adult Upper 2": "true"
   locations:
     "Spirit Temple Mirror Shield": "true"
+
 "Spirit Temple Adult Climb":
   dungeon: Spirit
   exits:
@@ -161,6 +174,7 @@
     "MQ Spirit Temple SR Adult Skulltula": "true"
     "MQ Spirit Temple Pot Topmost Climb 1": "true"
     "MQ Spirit Temple Pot Topmost Climb 2": "true"
+
 "Spirit Temple Top Floor":
   dungeon: Spirit
   events:

--- a/data/world/oot/dungeons_mq/water_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/water_temple_mq.yml
@@ -6,6 +6,7 @@
     "Water Temple Entrance": "can_swim || (hookshot_anywhere && has_iron_boots)"
   events:
     WATER_MQ_BRONZE_SCALE_SOFTLOCK_PREVENTION: "can_swim" #This is solely for the fact Water MQ can cause softlocks in its current state. Yes, while it might falsely flag a scale as being required for some checks that might not otherwise need it, it at least makes it playable.
+
 "Water Temple Entrance":
   dungeon: Water
   exits:
@@ -14,6 +15,7 @@
     "Water Temple Main Room Middle Floor": "event(WATER_MQ_BRONZE_SCALE_SOFTLOCK_PREVENTION) && (event(WATER_LEVEL_MID) || (has_iron_boots && has_tunic_zora) || (event(WATER_LEVEL_LOW) && hookshot_anywhere))"
     "Water Temple Main Room Bottom Floor": "event(WATER_MQ_BRONZE_SCALE_SOFTLOCK_PREVENTION) && (event(WATER_LEVEL_LOW) || (has_iron_boots && has_tunic_zora))"
     "Water Temple High Water Level Ledge": "event(WATER_MQ_BRONZE_SCALE_SOFTLOCK_PREVENTION) && longshot_anywhere"
+
 "Water Temple Main Room Top Floor":
   dungeon: Water
   exits:
@@ -25,6 +27,7 @@
     "Water Temple Main Room Antichamber Ledge": "((can_longshot || can_use_ice_arrow_platforms || (trick(OOT_WATER_BOSSBOOTS) && is_adult && has_iron_boots && can_swim)) && event(WATER_LEVEL_HIGH)) || climb_anywhere || longshot_anywhere"
     "Water Temple Storage Room": "((event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) && (can_hookshot || climb_anywhere)) || (event(WATER_LEVEL_HIGH) && has_iron_boots && can_hookshot && has_tunic_zora)"
     "Water Temple Lizalfos Hallway": "(event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) || (has_iron_boots && has_tunic_zora_strict && event(WATER_LEVEL_HIGH))"
+
 "Water Temple Main Room Middle Floor":
   dungeon: Water
   exits:
@@ -37,6 +40,7 @@
     "Water Temple Central Tower Middle Door": "event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID) || (event(WATER_LEVEL_HIGH) && has_iron_boots && has_tunic_zora)"
     "Water Temple Lizalfos Hallway": "((event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) && (hookshot_anywhere || has_hover_boots)) || (has_iron_boots && has_tunic_zora_strict && event(WATER_LEVEL_HIGH))"
     "Water Temple Main Room Antichamber Ledge": "(event(WATER_LEVEL_HIGH) && can_longshot) || longshot_anywhere"
+
 "Water Temple Main Room Bottom Floor":
   dungeon: Water
   exits:
@@ -49,6 +53,7 @@
     "Water Temple Leading To Side Loop Before Spikes": "event(WATER_GATES) && (((event(WATER_LEVEL_MID) || event(WATER_LEVEL_HIGH)) && has_iron_boots && has_tunic_zora) || (event(WATER_LEVEL_LOW) && (has_iron_boots || hookshot_anywhere || can_dive_small)))"
     "Water Temple Storage Room": "event(WATER_LEVEL_MID) || (event(WATER_LEVEL_HIGH) && has_iron_boots && has_tunic_zora) || (event(WATER_LEVEL_LOW) && longshot_anywhere)"
     "Water Temple Lizalfos Hallway": "event(WATER_LEVEL_MID) || (event(WATER_LEVEL_LOW) && longshot_anywhere) || (event(WATER_LEVEL_HIGH) && has_iron_boots && has_tunic_zora)"
+
 "Water Temple Ruto Column Bottom":
   dungeon: Water
   exits:
@@ -59,6 +64,7 @@
   locations:
     "MQ Water Temple Pot Ruto 1": "can_hookshot || event(WATER_LEVEL_LOW)"
     "MQ Water Temple Pot Ruto 2": "can_hookshot || event(WATER_LEVEL_LOW)"
+
 "Water Temple Compass Room":
   dungeon: Water
   exits:
@@ -68,6 +74,7 @@
   locations:
     "MQ Water Temple Compass Chest": "event(RUTO_COLUMN_HOOKSHOTS)"
     "MQ Water Temple Wonder Item Lizalfos Room": "can_hookshot"
+
 "Water Temple Ruto Column Middle":
   dungeon: Water
   exits:
@@ -76,6 +83,7 @@
   locations:
     "MQ Water Temple Longshot Chest": "event(WATER_LEVEL_LOW) && can_hookshot && can_damage"
     "MQ Water Temple Wonder Item Longshot Room": "can_hookshot"
+
 "Water Temple Ruto Column Top":
   dungeon: Water
   exits:
@@ -84,6 +92,7 @@
     "Water Temple Map Chest Room": "has_fire"
   events:
     WATER_LEVEL_LOW: "song_event(0x0b)"
+
 "Water Temple Map Chest Room":
   dungeon: Water
   exits:
@@ -91,6 +100,7 @@
   locations:
     "MQ Water Temple Map Chest": "can_hookshot"
     "MQ Water Temple Wonder Item Stalfos Room": "can_hookshot"
+
 "Water Temple Storage Room":
   dungeon: Water
   exits:
@@ -114,11 +124,13 @@
     "MQ Water Temple Storage Room Small Crate 2": "true"
     "MQ Water Temple Storage Room Small Crate 3": "true"
     "MQ Water Temple Storage Room Small Crate 4": "true"
+
 "Water Temple Hookshot Staircase from Main":
   dungeon: Water
   exits:
     "Water Temple Main Room Top Floor": "small_keys_water(1) && event(WATER_LEVEL_HIGH)"
     "Water Temple Hookshot Staircase Before Dark Link": "can_longshot"
+
 "Water Temple Hookshot Staircase Before Dark Link":
   dungeon: Water
   exits:
@@ -131,6 +143,7 @@
     "MQ Water Temple Wonder Item Hookshot Staircase Left 1": "can_hookshot"
     "MQ Water Temple Wonder Item Hookshot Staircase Left 2": "can_hookshot"
     "MQ Water Temple Wonder Item Hookshot Staircase Left 3": "can_hookshot"
+
 "Water Temple Room Before Dark Link Lower":
   dungeon: Water
   exits:
@@ -141,6 +154,7 @@
     "MQ Water Temple Pot Before Dark Link Ledge 2": "(soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon && can_hookshot) || has_hover_boots || hookshot_anywhere || climb_anywhere"
     "MQ Water Temple Pot Before Dark Link Ledge 3": "(soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon && can_hookshot) || has_hover_boots || hookshot_anywhere || climb_anywhere"
     "MQ Water Temple Big Fairy Before Dark Link Ledge": "can_play_sun && ((soul_enemy(SOUL_ENEMY_STALFOS) && has_weapon && can_hookshot) || has_hover_boots || hookshot_anywhere || climb_anywhere)"
+
 "Water Temple Room Before Dark Link Upper":
   dungeon: Water
   exits:
@@ -151,11 +165,13 @@
     "MQ Water Temple Pot Before Dark Link Near Door 2": "true"
     "MQ Water Temple Big Fairy Before Dark Link Near Door 1": "can_play_sun"
     "MQ Water Temple Big Fairy Before Dark Link Near Door 2": "can_play_storms"
+
 "Water Temple Dark Link":
   dungeon: Water
   exits:
     "Water Temple Room Before Dark Link Upper": "soul_enemy(SOUL_ENEMY_DARK_LINK) && has_weapon"
     "Water Temple After Dark Link": "soul_enemy(SOUL_ENEMY_DARK_LINK) && has_weapon"
+
 "Water Temple After Dark Link":
   dungeon: Water
   exits:
@@ -165,6 +181,7 @@
     "MQ Water Temple Wonder Item After Dark Link": "can_hookshot"
     "MQ Water Temple Pot After Dark Link 1": "true"
     "MQ Water Temple Pot After Dark Link 2": "true"
+
 "Water Temple River Start":
   dungeon: Water
   exits:
@@ -174,11 +191,13 @@
     "MQ Water Temple GS River": "gs && can_collect_distance" #Believe it or not, this is very easy to get with no Iron Boots.
     "MQ Water Temple Pot River 1": "true"
     "MQ Water Temple Pot River 2": "true"
+
 "Water Temple River End":
   dungeon: Water
   exits:
     "Water Temple River Start": "has_iron_boots && can_hookshot"
     "Water Temple Dragon Room": "true"
+
 "Water Temple Dragon Room":
   dungeon: Water
   exits:
@@ -199,6 +218,7 @@
     "MQ Water Temple Dragon Room At Torches Small Crate 1": "can_dive_small && has_tunic_zora" #Scale and timing can be used to dive here to reach the portrait section.
     "MQ Water Temple Dragon Room At Torches Small Crate 2": "can_dive_small && has_tunic_zora" #Scale and timing can be used to dive here to reach the portrait section.
     "MQ Water Temple Dragon Room At Torches Small Crate 3": "can_dive_small && has_tunic_zora" #Scale and timing can be used to dive here to reach the portrait section.
+
 "Water Temple Boss Key Room Dragon Side":
   dungeon: Water
   exits:
@@ -211,6 +231,7 @@
     "MQ Water Temple Boss Key Room In Center Large Crate 2": "true"
     "MQ Water Temple Boss Key Room In Center Large Crate 3": "true"
     "MQ Water Temple Boss Key Room In Center Large Crate 4": "true"
+
 "Water Temple Boss Key Room Switch Side":
   dungeon: Water
   exits:
@@ -220,6 +241,7 @@
     WATER_GATES: "has_iron_boots && has_tunic_zora"
   locations:
     "MQ Water Temple Boss Key Chest": "true"
+
 "Water Temple Three Torch Room":
   dungeon: Water
   exits:
@@ -243,16 +265,19 @@
     "MQ Water Temple Three Torch Room Behind Gate Large Crate 1": "event(WATER_MQ_THREE_TORCH_ROOM_GATE) && (scarecrow_hookshot || has_hover_boots || hookshot_anywhere || climb_anywhere)"
     "MQ Water Temple Three Torch Room Behind Gate Large Crate 2": "event(WATER_MQ_THREE_TORCH_ROOM_GATE) && (scarecrow_hookshot || has_hover_boots || hookshot_anywhere || climb_anywhere)"
     "MQ Water Temple Three Torch Room Behind Gate Large Crate 3": "event(WATER_MQ_THREE_TORCH_ROOM_GATE) && (scarecrow_hookshot || has_hover_boots || hookshot_anywhere || climb_anywhere)"
+
 "Water Temple Leading To Side Loop Before Spikes":
   dungeon: Water
   exits:
     "Water Temple Main Room Bottom Floor": "event(WATER_GATES) && has_iron_boots && has_tunic_zora"
     "Water Temple Leading To Side Loop After Spikes": "can_longshot || can_use_ice_arrow_platforms || hookshot_anywhere || climb_anywhere"
+
 "Water Temple Leading To Side Loop After Spikes":
   dungeon: Water
   exits:
     "Water Temple Side Loop Gate Room Main": "true"
     "Water Temple Leading To Side Loop Before Spikes": "true"
+
 "Water Temple Side Loop Gate Room Main":
   dungeon: Water
   exits:
@@ -268,12 +293,14 @@
     "MQ Water Temple Side Loop First Room Water Large Crate 4": "has_iron_boots && has_tunic_zora"
     "MQ Water Temple Side Loop First Room Water Large Crate 5": "has_iron_boots && has_tunic_zora"
     "MQ Water Temple Side Loop First Room Water Large Crate 6": "has_iron_boots && has_tunic_zora"
+
 "Water Temple Side Loop Scarecrow Alcove":
   dungeon: Water
   exits:
     "Water Temple Side Loop Gate Room Main": "true"
     "Water Temple Side Loop Room After Locked Door Switch Side": "small_keys_water(2)"
     "Water Temple Side Loop Scarecrow Alcove Underwater Path": "(has_iron_boots && has_tunic_zora) || (hookshot_anywhere && has_tunic_zora)"
+
 "Water Temple Side Loop Room After Locked Door Switch Side":
   dungeon: Water
   exits:
@@ -282,6 +309,7 @@
   locations:
     "MQ Water Temple Wonder Item Water Sprouts 1": "can_hookshot || (has_explosives_or_hammer || can_hit_triggers_distance || can_use_sword_or_sticks)"
     "MQ Water Temple Wonder Item Water Sprouts 2": "can_hookshot || (has_explosives_or_hammer || can_hit_triggers_distance || can_use_sword_or_sticks)"
+
 "Water Temple Side Loop Room After Locked Door Target Side":
   dungeon: Water
   exits:
@@ -290,6 +318,7 @@
   locations:
     "MQ Water Temple Wonder Item Water Sprouts 1": "(can_hit_triggers_distance || can_longshot) || (climb_anywhere && (has_explosives_or_hammer || can_hit_triggers_distance || can_use_sword_or_sticks))"
     "MQ Water Temple Wonder Item Water Sprouts 2": "(can_hit_triggers_distance || can_longshot) || (climb_anywhere && (has_explosives_or_hammer || can_hit_triggers_distance || can_use_sword_or_sticks))"
+
 "Water Temple Side Loop Dodongo Room":
   dungeon: Water
   exits:
@@ -303,6 +332,7 @@
     "MQ Water Temple Dodongo Room Large Crate 3": "true"
     "MQ Water Temple Dodongo Room Large Crate 4": "true"
     "MQ Water Temple Dodongo Room Large Crate 5": "true"
+
 "Water Temple Side Loop Gate Room Past Gate":
   dungeon: Water
   exits:
@@ -314,11 +344,13 @@
     "MQ Water Temple Side Loop First Room In Gate Large Crate 2": "true"
     "MQ Water Temple Side Loop First Room In Gate Large Crate 3": "true"
     "MQ Water Temple Side Loop First Room In Gate Large Crate 4": "true"
+
 "Water Temple Side Loop Scarecrow Alcove Underwater Path":
   dungeon: Water
   exits:
     "Water Temple Side Loop Scarecrow Alcove": "(has_iron_boots && has_tunic_zora) || (hookshot_anywhere && has_tunic_zora) || can_dive_small"
     "Water Temple Side Loop Stalfos Room": "true"
+
 "Water Temple Side Loop Stalfos Room":
   dungeon: Water
   exits:
@@ -333,6 +365,7 @@
     "MQ Water Temple Side Loop Stalfos Room Large Crate 3": "true"
     "MQ Water Temple Side Loop Stalfos Room Large Crate 4": "true"
     "MQ Water Temple Side Loop Stalfos Room Large Crate 5": "true"
+
 "Water Temple Main Room Antichamber Ledge":
   dungeon: Water
   exits:
@@ -340,6 +373,7 @@
     "Water Temple Antichamber Room": "true"
     "Water Temple Main Room Middle Floor": "can_longshot && ((event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) || (event(WATER_LEVEL_HIGH) && has_iron_boots && has_tunic_zora))"
     "Water Temple Main Room Bottom Floor": "event(WATER_LEVEL_LOW) || ((event(WATER_LEVEL_MID) || event(WATER_LEVEL_HIGH)) && has_iron_boots && has_tunic_zora)"
+
 "Water Temple Antichamber Room":
   dungeon: Water
   exits:
@@ -348,12 +382,14 @@
   locations:
     "MQ Water Temple Wonder Item Before Boss 1": "can_hookshot"
     "MQ Water Temple Wonder Item Before Boss 2": "can_hookshot"
+
 "Water Temple Central Tower Lower Door":
   dungeon: Water
   exits:
     "Water Temple Main Room Bottom Floor": "event(WATER_LEVEL_LOW) || (event(WATER_LEVEL_MID) && ((can_hookshot || is_adult) || climb_anywhere))"
     "Water Temple Central Tower Middle Door": "(event(WATER_LEVEL_MID) && is_adult) || can_longshot || hookshot_anywhere || climb_anywhere"
     "Water Temple Central Tower Under Gate": "event(WATER_CENTRAL_GATE) && (event(WATER_LEVEL_MID) || event(WATER_LEVEL_HIGH)) && has_iron_boots && has_tunic_zora_strict"
+
 "Water Temple Central Tower Middle Door":
   dungeon: Water
   exits:
@@ -366,6 +402,7 @@
   locations:
     "MQ Water Temple Central Tower Top Large Crate 1": "(event(WATER_LEVEL_HIGH) && (has_iron_boots || has_explosives_or_hammer)) || ((event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) && (can_longshot || hookshot_anywhere || climb_anywhere))"
     "MQ Water Temple Central Tower Top Large Crate 2": "(event(WATER_LEVEL_HIGH) && (has_iron_boots || has_explosives_or_hammer)) || ((event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) && (can_longshot || hookshot_anywhere || climb_anywhere))"
+
 "Water Temple Central Tower Under Gate":
   dungeon: Water
   exits:
@@ -387,6 +424,7 @@
     "MQ Water Temple Central Tower Under Gate Large Crate 12": "true"
     "MQ Water Temple Central Tower Under Gate Large Crate 13": "true"
     "MQ Water Temple Central Tower Under Gate Large Crate 14": "true"
+
 "Water Temple Lizalfos Hallway":
   dungeon: Water
   exits:
@@ -409,6 +447,7 @@
     "MQ Water Temple Lizalfos Hallway Large Crate 6": "(event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) || (event(WATER_LEVEL_HIGH) && has_iron_boots && has_tunic_zora)"
     "MQ Water Temple Lizalfos Hallway Large Crate 7": "(event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) || (event(WATER_LEVEL_HIGH) && has_iron_boots && has_tunic_zora)"
     "MQ Water Temple Lizalfos Hallway Large Crate 8": "(event(WATER_LEVEL_LOW) || event(WATER_LEVEL_MID)) || (event(WATER_LEVEL_HIGH) && has_iron_boots && has_tunic_zora)"
+
 "Water Temple High Water Level Ledge":
   dungeon: Water
   exits:
@@ -418,6 +457,7 @@
     "Water Temple Main Room Bottom Floor": "event(WATER_LEVEL_LOW) || ((event(WATER_LEVEL_MID) || event(WATER_LEVEL_HIGH)) && has_iron_boots && has_tunic_zora)"
   events:
     WATER_LEVEL_HIGH: "song_event(0x0b)"
+
 "Water Temple Blue Switch Path":
   dungeon: Water
   exits:
@@ -435,6 +475,7 @@
     "MQ Water Temple Room Before High Water Lower Large Crate 5": "true"
     "MQ Water Temple Room Before High Water Lower Large Crate 6": "true"
     "MQ Water Temple Room Before High Water Lower Small Crate": "true"
+
 "Water Temple Room Before Water Raise":
   dungeon: Water
   exits:


### PR DESCRIPTION
After the spacing was changed in a8a4ddb, MQ was not included, and this PR aims to resolve that and make consistent the spacing style with the rest of the logic files.