### PR TITLE
Two more boomerang logic additions

### DIFF
--- a/data/world/mm/overworld/clock_town.yml
+++ b/data/world/mm/overworld/clock_town.yml
@@ -102,7 +102,7 @@
     BOMBERS_NORTH3: "event(HIDE_SEEK3)"
     BOMBER_CODE: "bombers1 || bombers2 || bombers3"
     SAKON_BOMB_BAG: "can_fight && at(NIGHT1_AM_12_00)"
-    SAKON_BOOM: "(has_arrows || can_hookshot_short || can_use_din) && at(NIGHT1_AM_12_00)"
+    SAKON_BOOM: "(has_arrows || has_boomerang || can_hookshot_short || can_use_din) && at(NIGHT1_AM_12_00)"
     MAIL_LETTER: "has(LETTER_TO_KAFEI) && before(DAY2_AM_11_30)"
     PICTURE_TINGLE: "soul_npc(SOUL_NPC_TINGLE) && has(PICTOGRAPH_BOX) && is_day"
     RUPEES: "true"

--- a/data/world/mm/overworld/termina_field.yml
+++ b/data/world/mm/overworld/termina_field.yml
@@ -395,7 +395,7 @@
     "GLOBAL": "true"
     "Termina Field": "true"
   locations:
-    "Termina Field Bio Baba Grotto": "has_mask_zora || ((underwater_walking || can_dive_big || (trick(MM_BIO_BABA_LUCK) && soul_enemy(SOUL_ENEMY_BIO_BABA))) && (has_weapon_range || (has_bombs && soul_enemy(SOUL_ENEMY_BIO_BABA)) || (has_bombchu && trick(MM_BIO_BABA_CHU))))"
+    "Termina Field Bio Baba Grotto": "has_mask_zora || has_boomerang || ((underwater_walking || can_dive_big || (trick(MM_BIO_BABA_LUCK) && soul_enemy(SOUL_ENEMY_BIO_BABA))) && (has_weapon_range || (has_bombs && soul_enemy(SOUL_ENEMY_BIO_BABA)) || (has_bombchu && trick(MM_BIO_BABA_CHU))))"
     "Bio Baba Grotto Grass 1": "true"
     "Bio Baba Grotto Grass 2": "true"
     "Bio Baba Grotto Rock": "true"


### PR DESCRIPTION
-Blowing up Sakon with Boomerang has been added to logic.

-Bio Baba HP now can expect using only Boomerang to get it, it no longer drops the item out of bounds (I tested this) with it being consistent now it can be in logic.