### PR TITLE
Song event plando

### DIFF
--- a/packages/core/src/settings/patch.ts
+++ b/packages/core/src/settings/patch.ts
@@ -3,6 +3,7 @@ import type { Entrance } from '../data/data';
 
 import type { TrickKey } from './tricks';
 import type { Settings } from './type';
+import type { PlandoSongEvent, SongEventLocationOot, SongEventLocationMm } from '../song-events';
 
 type SettingsArrayAdd<T> = { add: T[] };
 type SettingsArrayRemove<T> = { remove: T[] };
@@ -15,6 +16,10 @@ export type SettingsPatch = PartialDeep<Omit<Settings, 'junkLocations' | 'tricks
   plando?: {
     locations?: null | {[k: string]: string | null};
     entrances?: null | Record<Entrance, Entrance | null>;
+    songEvents?: {
+      oot?: null | Partial<Record<SongEventLocationOot, PlandoSongEvent | null>>;
+      mm?: null | Partial<Record<SongEventLocationMm, PlandoSongEvent | null>>;
+    };
   };
   hints?: SettingsArrayPatch<Settings['hints'][number]>;
 };

--- a/packages/core/src/settings/type.ts
+++ b/packages/core/src/settings/type.ts
@@ -2,7 +2,7 @@ import type { Entrance } from '../data/data';
 import type { SettingHint } from './hints';
 import type { SpecialConds } from './special-conds';
 import type { TrickKey } from './tricks';
-
+import type { PlandoSongEvents } from '../song-events';
 import { SETTINGS } from './data';
 
 type SettingDataEnumValue = {
@@ -66,6 +66,7 @@ export type SettingsBase = UnionToIntersection<SettingShapes>;
 type SettingsPlando = {
   locations: {[k: string]: string | null};
   entrances: Record<Entrance, Entrance>;
+  songEvents: PlandoSongEvents;
 };
 export type Settings = SettingsBase & {
   startingItems: {[k: string]: number};

--- a/packages/core/src/settings/util.ts
+++ b/packages/core/src/settings/util.ts
@@ -8,7 +8,7 @@ import { DEFAULT_TRICKS, TRICKS } from './tricks';
 import { DEFAULT_SPECIAL_COND, DEFAULT_SPECIAL_CONDS, SPECIAL_CONDS, SPECIAL_CONDS_FIELDS } from './special-conds';
 import { patchArray } from './patch';
 import { SETTINGS_DEFAULT_HINTS } from './hints';
-import { SongEventSongs, SONG_EVENT_LOCATIONS_OOT, SONG_EVENT_LOCATIONS_MM } from '../song-events';
+import { SongEventSongs, SONG_EVENT_LOCATIONS_OOT, SONG_EVENT_LOCATIONS_MM, type PlandoSongEvent } from '../song-events';
 
 export const DEFAULT_SETTINGS: Settings = { ...SETTINGS.map(s => {
   if (s.type === 'set') {
@@ -182,45 +182,39 @@ function sortCopyObject<T extends {[k: string]: any}>(obj: T): T {
 }
 
 function sortCopySongEvents<T extends readonly string[]>(
-    obj: unknown,
+    obj: Partial<Record<T[number], Partial<PlandoSongEvent>>> | undefined,
     validEvents: T,
-): Partial<Record<T[number], { song: SongEventSongs | 'random'; group?: string }>> {
-  const result: Partial<Record<T[number], { song: SongEventSongs | 'random'; group?: string }>> = {};
+): Partial<Record<T[number], PlandoSongEvent>> {
+  const result: Partial<Record<T[number], PlandoSongEvent>> = {};
 
   if (!obj || typeof obj !== 'object') {
     return result;
   }
 
-  const valid = new Set<string>(validEvents as readonly string[]);
+  const valid = new Set<string>(validEvents);
 
-  for (const event of Object.keys(obj as Record<string, unknown>).sort()) {
+  for (const event of Object.keys(obj).sort()) {
     if (!valid.has(event)) {
       continue;
     }
 
-    const data = (obj as Record<string, unknown>)[event];
+    const key = event as T[number];
+    const data = obj[key];
+
     if (!data || typeof data !== 'object') {
       continue;
     }
 
-    const song = (data as { song?: unknown }).song;
-    const group = (data as { group?: unknown }).group;
+    const { song, group } = data;
 
-    const resultData: {
-      song: SongEventSongs | 'random';
-      group?: string;
-    } = {} as {
-      song: SongEventSongs | 'random';
-      group?: string;
-    };
+    if (song === 'random') {
+      const resultData: PlandoSongEvent = { song };
 
     if (typeof group === 'string' && group.length > 0) {
       resultData.group = group;
     }
 
-    if (song === 'random') {
-      resultData.song = song;
-      result[event as T[number]] = resultData;
+      result[key] = resultData;
       continue;
     }
 
@@ -233,8 +227,13 @@ function sortCopySongEvents<T extends readonly string[]>(
       continue;
     }
 
-    resultData.song = song;
-    result[event as T[number]] = resultData;
+    const resultData: PlandoSongEvent = { song };
+
+    if (typeof group === 'string' && group.length > 0) {
+      resultData.group = group;
+    }
+
+    result[key] = resultData;
   }
 
   return result;

--- a/packages/core/src/settings/util.ts
+++ b/packages/core/src/settings/util.ts
@@ -8,6 +8,7 @@ import { DEFAULT_TRICKS, TRICKS } from './tricks';
 import { DEFAULT_SPECIAL_COND, DEFAULT_SPECIAL_CONDS, SPECIAL_CONDS, SPECIAL_CONDS_FIELDS } from './special-conds';
 import { patchArray } from './patch';
 import { SETTINGS_DEFAULT_HINTS } from './hints';
+import { SongEventSongs, SONG_EVENT_LOCATIONS_OOT, SONG_EVENT_LOCATIONS_MM } from '../song-events';
 
 export const DEFAULT_SETTINGS: Settings = { ...SETTINGS.map(s => {
   if (s.type === 'set') {
@@ -20,7 +21,7 @@ export const DEFAULT_SETTINGS: Settings = { ...SETTINGS.map(s => {
   junkLocations: [] as string[],
   tricks: [ ...DEFAULT_TRICKS ],
   specialConds: { ...DEFAULT_SPECIAL_CONDS },
-  plando: { locations: {}, entrances: {} },
+  plando: { locations: {}, entrances: {}, songEvents: { oot: {}, mm: {} } },
   hints: [ ...SETTINGS_DEFAULT_HINTS ],
 } as Settings;
 
@@ -68,6 +69,12 @@ function validateSettingsStep(settings: Settings): Settings {
     if (s.games === 'oot') s.goal = 'ganon';
     if (s.games === 'mm') s.goal = 'majora';
   }
+
+  /* Validate plando song events */
+  s.plando.songEvents = {
+    oot: sortCopySongEvents(s.plando.songEvents?.oot, SONG_EVENT_LOCATIONS_OOT),
+    mm: sortCopySongEvents(s.plando.songEvents?.mm, SONG_EVENT_LOCATIONS_MM),
+  } as Settings['plando']['songEvents'];
 
   /* Specific validation */
   for (const data of SETTINGS) {
@@ -174,6 +181,65 @@ function sortCopyObject<T extends {[k: string]: any}>(obj: T): T {
   return result as T;
 }
 
+function sortCopySongEvents<T extends readonly string[]>(
+    obj: unknown,
+    validEvents: T,
+): Partial<Record<T[number], { song: SongEventSongs | 'random'; group?: string }>> {
+  const result: Partial<Record<T[number], { song: SongEventSongs | 'random'; group?: string }>> = {};
+
+  if (!obj || typeof obj !== 'object') {
+    return result;
+  }
+
+  const valid = new Set<string>(validEvents as readonly string[]);
+
+  for (const event of Object.keys(obj as Record<string, unknown>).sort()) {
+    if (!valid.has(event)) {
+      continue;
+    }
+
+    const data = (obj as Record<string, unknown>)[event];
+    if (!data || typeof data !== 'object') {
+      continue;
+    }
+
+    const song = (data as { song?: unknown }).song;
+    const group = (data as { group?: unknown }).group;
+
+    const resultData: {
+      song: SongEventSongs | 'random';
+      group?: string;
+    } = {} as {
+      song: SongEventSongs | 'random';
+      group?: string;
+    };
+
+    if (typeof group === 'string' && group.length > 0) {
+      resultData.group = group;
+    }
+
+    if (song === 'random') {
+      resultData.song = song;
+      result[event as T[number]] = resultData;
+      continue;
+    }
+
+    if (
+        typeof song !== 'number' ||
+        !Number.isInteger(song) ||
+        song < SongEventSongs.ZELDAS_LULLABY ||
+        song > SongEventSongs.OATH
+    ) {
+      continue;
+    }
+
+    resultData.song = song;
+    result[event as T[number]] = resultData;
+  }
+
+  return result;
+}
+
 export function makeSettings(arg: PartialDeep<Settings>): Settings {
   /* Clone the base setting to avoid mutating it */
   const result = cloneDeep(DEFAULT_SETTINGS);
@@ -215,6 +281,13 @@ export function makeSettings(arg: PartialDeep<Settings>): Settings {
     if (arg.plando.entrances !== undefined) {
       result.plando.entrances = sortCopyObject({ ...arg.plando.entrances }) as Settings['plando']['entrances'];
     }
+
+    if (arg.plando.songEvents !== undefined) {
+      result.plando.songEvents = {
+        oot: sortCopySongEvents(arg.plando.songEvents.oot, SONG_EVENT_LOCATIONS_OOT),
+        mm: sortCopySongEvents(arg.plando.songEvents.mm, SONG_EVENT_LOCATIONS_MM),
+      } as Settings['plando']['songEvents'];
+    }
   }
 
   if (arg.hints !== undefined) {
@@ -235,6 +308,28 @@ function applyKeyValue<K extends string, V>(data: Record<K, V>, patch: undefined
     if (value === null) {
       delete result[key];
     } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function applyPartialKeyValue<K extends string, V>(
+    data: Partial<Record<K, V>>,
+    patch: undefined | null | Partial<Record<K, V | null>>,
+): Partial<Record<K, V>> {
+  if (patch === undefined) {
+    return data;
+  }
+  if (patch === null) {
+    return {};
+  }
+  const result = { ...data };
+  for (const key in patch) {
+    const value = patch[key];
+    if (value === null) {
+      delete result[key];
+    } else if (value !== undefined) {
       result[key] = value;
     }
   }
@@ -273,6 +368,18 @@ export function mergeSettings(settings: Settings, patch: SettingsPatch): Setting
   if (patch.plando !== undefined) {
     s.plando.locations = applyKeyValue(s.plando.locations, patch.plando.locations);
     s.plando.entrances = applyKeyValue(s.plando.entrances, patch.plando.entrances);
+
+    if (patch.plando.songEvents !== undefined) {
+      s.plando.songEvents.oot = applyPartialKeyValue(
+          s.plando.songEvents.oot,
+          patch.plando.songEvents.oot,
+      ) as Settings['plando']['songEvents']['oot'];
+
+      s.plando.songEvents.mm = applyPartialKeyValue(
+          s.plando.songEvents.mm,
+          patch.plando.songEvents.mm,
+      ) as Settings['plando']['songEvents']['mm'];
+    }
   }
 
   /* Apply hints */

--- a/packages/core/src/song-events.ts
+++ b/packages/core/src/song-events.ts
@@ -20,3 +20,61 @@ export enum SongEventSongs {
   ELEGY,
   OATH,
 }
+
+export const SONG_EVENT_LOCATIONS_OOT = [
+  'SONG_EVENT_TEMPLE_OF_TIME',
+  'SONG_EVENT_WINDMILL',
+  'SONG_EVENT_GRAVEYARD',
+  'SONG_EVENT_ZORA_RIVER',
+  'SONG_EVENT_GORON_CITY',
+  'SONG_EVENT_GREAT_FAIRY_SPELL_WIND',
+  'SONG_EVENT_GREAT_FAIRY_SPELL_FIRE',
+  'SONG_EVENT_GREAT_FAIRY_SPELL_LOVE',
+  'SONG_EVENT_GREAT_FAIRY_UPGRADE_MAGIC',
+  'SONG_EVENT_GREAT_FAIRY_UPGRADE_MAGIC2',
+  'SONG_EVENT_GREAT_FAIRY_UPGRADE_DEFENSE',
+  'SONG_EVENT_TEMPLE_WATER',
+  'SONG_EVENT_TEMPLE_SHADOW',
+  'SONG_EVENT_TEMPLE_SPIRIT_STATUE',
+  'SONG_EVENT_TEMPLE_SPIRIT_LOWER',
+  'SONG_EVENT_TEMPLE_SPIRIT_HIGHER',
+  'SONG_EVENT_TEMPLE_BOTW',
+  'SONG_EVENT_TEMPLE_GANON',
+] as const;
+
+export const SONG_EVENT_LOCATIONS_MM = [
+  'SONG_EVENT_TEMPLE_WOODFALL',
+  'SONG_EVENT_TEMPLE_SNOWHEAD',
+  'SONG_EVENT_TEMPLE_GREATBAY',
+  //'SONG_EVENT_HEALING_POEHUT',
+  'SONG_EVENT_HEALING_DARMANI',
+  'SONG_EVENT_HEALING_PAMELA_FATHER',
+  'SONG_EVENT_HEALING_KAMARO',
+  'SONG_EVENT_HEALING_MIKAU',
+  'SONG_EVENT_AWAKENING_KEETA',
+  //'SONG_EVENT_AWAKENING_SCRUB',
+  'SONG_EVENT_LULLABY_KID',
+  'SONG_EVENT_STORMS_COMPOSER',
+  'SONG_EVENT_CLOCK_TOWER_ROOF',
+] as const;
+
+export type SongEventLocationOot = typeof SONG_EVENT_LOCATIONS_OOT[number];
+export type SongEventLocationMm = typeof SONG_EVENT_LOCATIONS_MM[number];
+
+export type PlandoSongEvent = {
+  song: SongEventSongs | 'random';
+  group?: string;
+};
+
+export type PlandoSongEvents = {
+  oot: Partial<Record<SongEventLocationOot, PlandoSongEvent>>;
+  mm: Partial<Record<SongEventLocationMm, PlandoSongEvent>>;
+};
+
+export const SONG_EVENT_INDEX_OOT = Object.fromEntries(
+    SONG_EVENT_LOCATIONS_OOT.map((k, i) => [k, i]),
+) as Record<SongEventLocationOot, number>;
+
+export const SONG_EVENT_INDEX_MM = Object.fromEntries(
+    SONG_EVENT_LOCATIONS_MM.map((k, i) => [k, i]),
+) as Record<SongEventLocationMm, number>;

--- a/packages/generator/lib/combo/presets.ts
+++ b/packages/generator/lib/combo/presets.ts
@@ -741,7 +741,7 @@ const PRESET_HELL = makeSettings({
   progressiveSwordsOot: 'separate',
   progressiveShieldsMm: 'separate',
   progressiveGoronLullabyMm: 'progressive',
-  progressiveGoronLullabyOot: 'progresive',
+  progressiveGoronLullabyOot: 'progressive',
   progressiveClocks: 'separate',
   bottleContentShuffle: true,
   stoneAgonyMm: true,

--- a/packages/gui/src/app/components/SongEventPlando.tsx
+++ b/packages/gui/src/app/components/SongEventPlando.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FaXmark } from 'react-icons/fa6';
-import { Button, Card, MultiSelect, Select } from './ui';
+import { Button, Card, MultiSelect, Select, Tooltip } from './ui';
 import { useStore } from '../store';
 
 const SONG_EVENT_LOCATIONS_OOT = [
@@ -772,8 +772,14 @@ export function SongEventPlando() {
 
     return (
         <main className="h-full min-h-0 flex flex-col">
-            <nav className="flex gap-2">
+            <nav className="flex items-end gap-2">
                 <div className="flex-1">
+                    <div className="mb-1 flex justify-start">
+                        <Tooltip>
+                            Assigning Random to a group of events will assign the same randomized song to all events in a group
+                        </Tooltip>
+                    </div>
+
                     <Select
                         searcheable
                         placeholder="Song"

--- a/packages/gui/src/app/components/SongEventPlando.tsx
+++ b/packages/gui/src/app/components/SongEventPlando.tsx
@@ -1,0 +1,876 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FaXmark } from 'react-icons/fa6';
+import { Button, Card, MultiSelect, Select } from './ui';
+import { useStore } from '../store';
+
+const SONG_EVENT_LOCATIONS_OOT = [
+    'SONG_EVENT_TEMPLE_OF_TIME',
+    'SONG_EVENT_WINDMILL',
+    'SONG_EVENT_GRAVEYARD',
+    'SONG_EVENT_ZORA_RIVER',
+    'SONG_EVENT_GORON_CITY',
+    'SONG_EVENT_GREAT_FAIRY_SPELL_WIND',
+    'SONG_EVENT_GREAT_FAIRY_SPELL_FIRE',
+    'SONG_EVENT_GREAT_FAIRY_SPELL_LOVE',
+    'SONG_EVENT_GREAT_FAIRY_UPGRADE_MAGIC',
+    'SONG_EVENT_GREAT_FAIRY_UPGRADE_MAGIC2',
+    'SONG_EVENT_GREAT_FAIRY_UPGRADE_DEFENSE',
+    'SONG_EVENT_TEMPLE_WATER',
+    'SONG_EVENT_TEMPLE_SHADOW',
+    'SONG_EVENT_TEMPLE_SPIRIT_STATUE',
+    'SONG_EVENT_TEMPLE_SPIRIT_LOWER',
+    'SONG_EVENT_TEMPLE_SPIRIT_HIGHER',
+    'SONG_EVENT_TEMPLE_BOTW',
+    'SONG_EVENT_TEMPLE_GANON',
+] as const;
+
+const SONG_EVENT_LOCATIONS_MM = [
+    'SONG_EVENT_TEMPLE_WOODFALL',
+    'SONG_EVENT_TEMPLE_SNOWHEAD',
+    'SONG_EVENT_TEMPLE_GREATBAY',
+    // commented out because its not currently in use in the pool
+    //'SONG_EVENT_HEALING_POEHUT',
+    'SONG_EVENT_HEALING_DARMANI',
+    'SONG_EVENT_HEALING_PAMELA_FATHER',
+    'SONG_EVENT_HEALING_KAMARO',
+    'SONG_EVENT_HEALING_MIKAU',
+    'SONG_EVENT_AWAKENING_KEETA',
+    // commented out because its not currently use in the pool
+    //'SONG_EVENT_AWAKENING_SCRUB',
+    'SONG_EVENT_LULLABY_KID',
+    'SONG_EVENT_STORMS_COMPOSER',
+    'SONG_EVENT_CLOCK_TOWER_ROOF',
+] as const;
+
+const SONG_EVENT_SONGS = [
+    'ZELDAS_LULLABY',
+    'EPONAS',
+    'SARIAS',
+    'STORMS',
+    'SUNS',
+    'TIME',
+    'MINUET',
+    'BOLERO',
+    'SERENADE',
+    'REQUIEM',
+    'NOCTURNE',
+    'PRELUDE',
+    'HEALING',
+    'SOARING',
+    'SONATA',
+    'GORON_LULLABY',
+    'GORON_LULLABY_INTRO',
+    'NEW_WAVE',
+    'ELEGY',
+    'OATH',
+] as const;
+
+const RANDOM_SONG_EVENT_SONG = 'RANDOM' as const;
+const SONG_EVENT_GROUPS_STORAGE_KEY = 'song-event-plando-groups';
+
+type Game = 'oot' | 'mm';
+type Settings = ReturnType<typeof useStore.getState>['settings'];
+type SongEventSongName = typeof SONG_EVENT_SONGS[number];
+type PlandoSongEventSong = number | 'random';
+type SongEventLocationOot = typeof SONG_EVENT_LOCATIONS_OOT[number];
+type SongEventLocationMm = typeof SONG_EVENT_LOCATIONS_MM[number];
+
+type PlandoSongEventValue = {
+    song: PlandoSongEventSong;
+    group?: string;
+};
+
+type SongEventOption = {
+    key: string;
+    value: string;
+    label: string;
+    game: Game;
+};
+
+type SongEventGroup = {
+    id: string;
+    label: string;
+    song: string;
+    events: Array<{
+        game: Game;
+        event: string;
+    }>;
+};
+
+type SongEventGroups = Record<string, SongEventGroup | null>;
+
+const SONG_EVENT_SONG_NAMES: Record<SongEventSongName, string> = {
+    ZELDAS_LULLABY: "Zelda's Lullaby",
+    EPONAS: "Epona's Song",
+    SARIAS: "Saria's Song",
+    STORMS: "Song of Storms",
+    SUNS: "Sun's Song",
+    TIME: "Song of Time",
+    MINUET: "Minuet of Forest",
+    BOLERO: "Bolero of Fire",
+    SERENADE: "Serenade of Water",
+    REQUIEM: "Requiem of Spirit",
+    NOCTURNE: "Nocturne of Shadow",
+    PRELUDE: "Prelude of Light",
+    HEALING: "Song of Healing",
+    SOARING: "Song of Soaring",
+    SONATA: "Sonata of Awakening",
+    GORON_LULLABY: "Goron Lullaby",
+    GORON_LULLABY_INTRO: "Goron Lullaby Intro",
+    NEW_WAVE: "New Wave Bossa Nova",
+    ELEGY: "Elegy of Emptiness",
+    OATH: "Oath to Order",
+};
+
+const SONG_EVENT_LOCATION_NAMES: Record<string, string> = {
+    SONG_EVENT_TEMPLE_OF_TIME: 'Temple of Time',
+    SONG_EVENT_WINDMILL: 'Windmill',
+    SONG_EVENT_GRAVEYARD: 'Graveyard',
+    SONG_EVENT_ZORA_RIVER: 'Zora River',
+    SONG_EVENT_GORON_CITY: 'Goron City',
+    SONG_EVENT_GREAT_FAIRY_SPELL_WIND: 'Great Fairy - Farore’s Wind',
+    SONG_EVENT_GREAT_FAIRY_SPELL_FIRE: 'Great Fairy - Din’s Fire',
+    SONG_EVENT_GREAT_FAIRY_SPELL_LOVE: 'Great Fairy - Nayru’s Love',
+    SONG_EVENT_GREAT_FAIRY_UPGRADE_MAGIC: 'Great Fairy - Magic Upgrade',
+    SONG_EVENT_GREAT_FAIRY_UPGRADE_MAGIC2: 'Great Fairy - Double Magic',
+    SONG_EVENT_GREAT_FAIRY_UPGRADE_DEFENSE: 'Great Fairy - Defense Upgrade',
+    SONG_EVENT_TEMPLE_WATER: 'Water Temple',
+    SONG_EVENT_TEMPLE_SHADOW: 'Shadow Temple',
+    SONG_EVENT_TEMPLE_SPIRIT_STATUE: 'Spirit Temple Statue',
+    SONG_EVENT_TEMPLE_SPIRIT_LOWER: 'Spirit Temple Lower',
+    SONG_EVENT_TEMPLE_SPIRIT_HIGHER: 'Spirit Temple Higher',
+    SONG_EVENT_TEMPLE_BOTW: 'Bottom of the Well',
+    SONG_EVENT_TEMPLE_GANON: 'Ganon’s Castle',
+
+    SONG_EVENT_TEMPLE_WOODFALL: 'Woodfall Temple',
+    SONG_EVENT_TEMPLE_SNOWHEAD: 'Snowhead Temple',
+    SONG_EVENT_TEMPLE_GREATBAY: 'Great Bay Temple',
+    // commented out because its not currently use in the pool
+    //SONG_EVENT_HEALING_POEHUT: 'Song of Healing - Poe Hut',
+    SONG_EVENT_HEALING_DARMANI: 'Song of Healing - Darmani',
+    SONG_EVENT_HEALING_PAMELA_FATHER: 'Song of Healing - Pamela’s Father',
+    SONG_EVENT_HEALING_KAMARO: 'Song of Healing - Kamaro',
+    SONG_EVENT_HEALING_MIKAU: 'Song of Healing - Mikau',
+    SONG_EVENT_AWAKENING_KEETA: 'Sonata of Awakening - Keeta',
+    // commented out because its not currently use in the pool
+    //SONG_EVENT_AWAKENING_SCRUB: 'Sonata of Awakening - Deku Scrub',
+    SONG_EVENT_LULLABY_KID: 'Goron Lullaby - Elder’s Son',
+    SONG_EVENT_STORMS_COMPOSER: 'Song of Storms - Composer',
+    SONG_EVENT_CLOCK_TOWER_ROOF: 'Clock Tower Roof',
+};
+
+function getPlandoSongEvent(
+    plando: Settings['plando'],
+    game: Game,
+    event: string,
+): PlandoSongEventValue | undefined {
+    if (game === 'oot') {
+        return plando.songEvents?.oot?.[event as SongEventLocationOot] as PlandoSongEventValue | undefined;
+    }
+
+    return plando.songEvents?.mm?.[event as SongEventLocationMm] as PlandoSongEventValue | undefined;
+}
+
+function songEventKey(game: Game, event: string) {
+    return `${game}:${event}`;
+}
+
+function songEventSongValue(song: SongEventSongName): number {
+    return SONG_EVENT_SONGS.indexOf(song);
+}
+
+function songEventSongName(song: number) {
+    const key = SONG_EVENT_SONGS[song];
+    return key ? SONG_EVENT_SONG_NAMES[key] : `Unknown Song ${song}`;
+}
+
+function songEventLabel(event: string) {
+    return SONG_EVENT_LOCATION_NAMES[event] || event
+        .replace(/^SONG_EVENT_/, '')
+        .replace(/_/g, ' ')
+        .toLowerCase()
+        .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function unique<T>(items: T[]): T[] {
+    return Array.from(new Set(items));
+}
+
+function intersectSongPools(pools: number[][]): number[] {
+    if (pools.length === 0) {
+        return [];
+    }
+
+    return pools.reduce((shared, pool) => {
+        const poolSet = new Set(pool);
+        return shared.filter(song => poolSet.has(song));
+    });
+}
+
+function getEnabledSongEventGames(settings: Settings): Game[] {
+    return [
+        ...(settings.songEventsShuffleOot ? ['oot' as const] : []),
+        ...(settings.songEventsShuffleMm ? ['mm' as const] : []),
+    ];
+}
+
+function getAllowedSongPoolForGame(settings: Settings, game: Game): number[] {
+    if (game === 'oot') {
+        return unique([
+            songEventSongValue('ZELDAS_LULLABY'),
+            songEventSongValue('EPONAS'),
+            songEventSongValue('SARIAS'),
+            songEventSongValue('SUNS'),
+            songEventSongValue('TIME'),
+            songEventSongValue('STORMS'),
+            songEventSongValue('MINUET'),
+            songEventSongValue('BOLERO'),
+            songEventSongValue('SERENADE'),
+            songEventSongValue('REQUIEM'),
+            songEventSongValue('NOCTURNE'),
+            songEventSongValue('PRELUDE'),
+            ...(settings.songHealingOot ? [songEventSongValue('HEALING')] : []),
+            ...(settings.songSoaringOot ? [songEventSongValue('SOARING')] : []),
+            ...(settings.songAwakeningOot ? [songEventSongValue('SONATA')] : []),
+            ...(settings.songGoronOot ? [songEventSongValue('GORON_LULLABY')] : []),
+            ...(
+                settings.songGoronOot &&
+                settings.progressiveGoronLullabyOot === 'progressive'
+                    ? [songEventSongValue('GORON_LULLABY_INTRO')]
+                    : []
+            ),
+            ...(settings.songZoraOot ? [songEventSongValue('NEW_WAVE')] : []),
+            ...(settings.elegyOot ? [songEventSongValue('ELEGY')] : []),
+            ...(settings.songOrderOot ? [songEventSongValue('OATH')] : []),
+        ]);
+    }
+
+    return unique([
+        songEventSongValue('TIME'),
+        songEventSongValue('HEALING'),
+        songEventSongValue('EPONAS'),
+        songEventSongValue('SOARING'),
+        songEventSongValue('STORMS'),
+        songEventSongValue('SONATA'),
+        songEventSongValue('GORON_LULLABY'),
+        songEventSongValue('NEW_WAVE'),
+        // commented out because elegy is currently glitched in MM for song events.
+        // songEventSongValue('ELEGY'),
+        songEventSongValue('OATH'),
+        ...(settings.progressiveGoronLullabyMm === 'progressive'
+            ? [songEventSongValue('GORON_LULLABY_INTRO')]
+            : []),
+        ...(settings.songZeldaLullabyMm ? [songEventSongValue('ZELDAS_LULLABY')] : []),
+        ...(settings.songSariasMm ? [songEventSongValue('SARIAS')] : []),
+        ...(settings.songSunMm ? [songEventSongValue('SUNS')] : []),
+        ...(settings.songMinuetMm ? [songEventSongValue('MINUET')] : []),
+        ...(settings.songBoleroMm ? [songEventSongValue('BOLERO')] : []),
+        ...(settings.songSerenadeMm ? [songEventSongValue('SERENADE')] : []),
+        ...(settings.songRequiemMm ? [songEventSongValue('REQUIEM')] : []),
+        ...(settings.songNocturneMm ? [songEventSongValue('NOCTURNE')] : []),
+        ...(settings.songPreludeMm ? [songEventSongValue('PRELUDE')] : []),
+    ]);
+}
+
+function getAllowedSongPoolForGames(
+    settings: Settings,
+    games: Game[],
+    mode: 'union' | 'intersection'
+): number[] {
+    const pools = unique(games).map(game => getAllowedSongPoolForGame(settings, game));
+
+    return mode === 'intersection'
+        ? intersectSongPools(pools)
+        : unique(pools.flat());
+}
+
+function isSongAllowedForGame(settings: Settings, song: number, game: Game) {
+    return getAllowedSongPoolForGame(settings, game).includes(song);
+}
+
+function nextGroupId(groups: SongEventGroups, extraUsedIds: Iterable<string> = []) {
+    const used = new Set(
+        Object.keys(groups || {})
+            .map(id => Number(id.replace(/^group-/, '')))
+            .filter(Number.isFinite)
+    );
+
+    for (const id of extraUsedIds) {
+        const n = Number(id.replace(/^group-/, ''));
+        if (Number.isFinite(n)) {
+            used.add(n);
+        }
+    }
+
+    let next = 1;
+
+    while (used.has(next)) {
+        next += 1;
+    }
+
+    return `group-${next}`;
+}
+
+function groupLabelFromId(id: string) {
+    const n = Number(id.replace(/^group-/, ''));
+    return Number.isFinite(n) ? `Group ${n}` : id;
+}
+
+function loadSongEventGroups(): SongEventGroups {
+    if (typeof window === 'undefined') {
+        return {};
+    }
+
+    try {
+        const raw = window.localStorage.getItem(SONG_EVENT_GROUPS_STORAGE_KEY);
+        return raw ? JSON.parse(raw) as SongEventGroups : {};
+    } catch {
+        return {};
+    }
+}
+
+function saveSongEventGroups(groups: SongEventGroups) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    window.localStorage.setItem(
+        SONG_EVENT_GROUPS_STORAGE_KEY,
+        JSON.stringify(groups)
+    );
+}
+
+function formatPlandoSong(song: PlandoSongEventSong) {
+    return song === 'random'
+        ? 'Random'
+        : songEventSongName(song);
+}
+
+export function SongEventPlando() {
+    const settings = useStore(state => state.settings);
+    const plando = useStore(state => state.settings.plando);
+    const patchSettings = useStore(state => state.patchSettings);
+
+    const [selectedSong, setSelectedSongRaw] = useState<string | null>(null);
+    const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
+    const [songEventGroups, setSongEventGroups] = useState<SongEventGroups>(() => loadSongEventGroups());
+
+    useEffect(() => {
+        saveSongEventGroups(songEventGroups);
+    }, [songEventGroups]);
+
+    useEffect(() => {
+        const songEventsPatch: {
+            oot?: Record<string, PlandoSongEventValue>;
+            mm?: Record<string, PlandoSongEventValue>;
+        } = {};
+
+        let changed = false;
+
+        for (const group of Object.values(songEventGroups || {})) {
+            if (!group) {
+                continue;
+            }
+
+            for (const event of group.events) {
+                const data = getPlandoSongEvent(plando, event.game, event.event);
+
+                if (!data) {
+                    continue;
+                }
+
+                if (data.group === group.id) {
+                    continue;
+                }
+
+                songEventsPatch[event.game] ||= {};
+                songEventsPatch[event.game]![event.event] = {
+                    ...data,
+                    group: group.id,
+                };
+
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return;
+        }
+
+        patchSettings({
+            plando: {
+                songEvents: songEventsPatch,
+            },
+        });
+    }, [
+        patchSettings,
+        plando.songEvents,
+        songEventGroups,
+    ]);
+
+    const plandoGroupIds = useMemo(() => {
+        const ids = new Set<string>();
+
+        for (const data of Object.values(plando.songEvents?.oot || {}) as PlandoSongEventValue[]) {
+            if (data?.group) {
+                ids.add(data.group);
+            }
+        }
+
+        for (const data of Object.values(plando.songEvents?.mm || {}) as PlandoSongEventValue[]) {
+            if (data?.group) {
+                ids.add(data.group);
+            }
+        }
+
+        return ids;
+    }, [plando.songEvents]);
+
+    const baseEventOptions = useMemo(() => {
+        const options: SongEventOption[] = [];
+        const usedOotEvents = new Set(Object.keys(plando.songEvents?.oot || {}));
+        const usedMmEvents = new Set(Object.keys(plando.songEvents?.mm || {}));
+
+        if (settings.songEventsShuffleOot) {
+            options.push(...SONG_EVENT_LOCATIONS_OOT
+                .filter(event => !usedOotEvents.has(event))
+                .map(event => ({
+                    key: songEventKey('oot', event),
+                    value: event,
+                    label: `OoT - ${songEventLabel(event)}`,
+                    game: 'oot' as const,
+                })));
+        }
+
+        if (settings.songEventsShuffleMm) {
+            options.push(...SONG_EVENT_LOCATIONS_MM
+                .filter(event => !usedMmEvents.has(event))
+                .map(event => ({
+                    key: songEventKey('mm', event),
+                    value: event,
+                    label: `MM - ${songEventLabel(event)}`,
+                    game: 'mm' as const,
+                })));
+        }
+
+        return options;
+    }, [
+        plando.songEvents,
+        settings.songEventsShuffleOot,
+        settings.songEventsShuffleMm,
+    ]);
+
+    const selectedEventOptions = useMemo(() => {
+        return selectedEvents
+            .map(key => baseEventOptions.find(option => option.key === key))
+            .filter((option): option is SongEventOption => !!option);
+    }, [baseEventOptions, selectedEvents]);
+
+    const selectedEventGames = useMemo(() => {
+        return unique(selectedEventOptions.map(event => event.game));
+    }, [selectedEventOptions]);
+
+    const songOptions = useMemo(() => {
+        const games = selectedEventGames.length > 0
+            ? selectedEventGames
+            : getEnabledSongEventGames(settings);
+
+        const allowedSongs = getAllowedSongPoolForGames(
+            settings,
+            games,
+            selectedEventGames.length > 0 ? 'intersection' : 'union'
+        );
+
+        const allowedSongSet = new Set(allowedSongs);
+
+        return [
+            {
+                value: RANDOM_SONG_EVENT_SONG,
+                label: 'Random',
+            },
+            ...SONG_EVENT_SONGS
+                .map(song => songEventSongValue(song))
+                .filter(song => allowedSongSet.has(song))
+                .map(song => ({
+                    value: song.toString(),
+                    label: songEventSongName(song),
+                })),
+        ];
+    }, [
+        settings,
+        selectedEventGames,
+    ]);
+
+    const eventOptions = useMemo(() => {
+        return baseEventOptions.filter(option => {
+            if (!selectedSong) {
+                return true;
+            }
+
+            if (selectedSong !== RANDOM_SONG_EVENT_SONG) {
+                return isSongAllowedForGame(settings, Number(selectedSong), option.game);
+            }
+
+            const games = unique([
+                ...selectedEventOptions.map(event => event.game),
+                option.game,
+            ]);
+
+            return getAllowedSongPoolForGames(settings, games, 'intersection').length > 0;
+        });
+    }, [
+        baseEventOptions,
+        selectedSong,
+        selectedEventOptions,
+        settings,
+    ]);
+
+    useEffect(() => {
+        if (!selectedSong || selectedSong === RANDOM_SONG_EVENT_SONG) {
+            return;
+        }
+
+        if (!songOptions.some(option => option.value === selectedSong)) {
+            setSelectedSongRaw(null);
+        }
+    }, [selectedSong, songOptions]);
+
+    useEffect(() => {
+        setSelectedEvents(current => {
+            const validKeys = new Set(eventOptions.map(option => option.key));
+            const next = current.filter(key => validKeys.has(key));
+
+            return next.length === current.length
+                ? current
+                : next;
+        });
+    }, [eventOptions]);
+
+    const setSelectedSong = (song: string | null) => {
+        if (song) {
+            setSelectedSongRaw(song);
+        }
+    };
+
+    const placeSongEvent = useCallback(() => {
+        if (!selectedSong || selectedEventOptions.length === 0) {
+            return;
+        }
+
+        const selectedGames = unique(selectedEventOptions.map(event => event.game));
+        const allowedSongs = getAllowedSongPoolForGames(settings, selectedGames, 'intersection');
+
+        const song: PlandoSongEventSong =
+            selectedSong === RANDOM_SONG_EVENT_SONG
+                ? 'random'
+                : Number(selectedSong);
+
+        if (song === 'random') {
+            if (allowedSongs.length === 0) {
+                return;
+            }
+        } else if (
+            !Number.isInteger(song) ||
+            !allowedSongs.includes(song)
+        ) {
+            return;
+        }
+
+        const groupId = selectedEventOptions.length > 1
+            ? nextGroupId(songEventGroups, plandoGroupIds)
+            : undefined;
+
+        const nextSongEvents: {
+            oot?: Record<string, PlandoSongEventValue>;
+            mm?: Record<string, PlandoSongEventValue>;
+        } = {};
+
+        for (const event of selectedEventOptions) {
+            nextSongEvents[event.game] ||= {};
+            nextSongEvents[event.game]![event.value] = {
+                song,
+                ...(groupId ? { group: groupId } : {}),
+            };
+        }
+
+        patchSettings({
+            plando: {
+                songEvents: nextSongEvents,
+            },
+        });
+
+        if (groupId) {
+            setSongEventGroups(current => ({
+                ...current,
+                [groupId]: {
+                    id: groupId,
+                    label: groupLabelFromId(groupId),
+                    song: selectedSong,
+                    events: selectedEventOptions.map(event => ({
+                        game: event.game,
+                        event: event.value,
+                    })),
+                },
+            }));
+        }
+
+        setSelectedSongRaw(null);
+        setSelectedEvents([]);
+    }, [
+        patchSettings,
+        plandoGroupIds,
+        selectedSong,
+        selectedEventOptions,
+        settings,
+        songEventGroups,
+    ]);
+
+    const removeSongEvent = useCallback((game: Game, event: string) => {
+        patchSettings({
+            plando: {
+                songEvents: {
+                    [game]: {
+                        [event]: null,
+                    },
+                },
+            },
+        });
+
+        setSelectedEvents(current =>
+            current.filter(key => key !== songEventKey(game, event))
+        );
+    }, [patchSettings]);
+
+    const removeGroup = useCallback((group: SongEventGroup) => {
+        const songEventsPatch: {
+            oot?: Record<string, null>;
+            mm?: Record<string, null>;
+        } = {};
+
+        for (const event of group.events) {
+            songEventsPatch[event.game] ||= {};
+            songEventsPatch[event.game]![event.event] = null;
+        }
+
+        patchSettings({
+            plando: {
+                songEvents: songEventsPatch,
+            },
+        });
+
+        setSongEventGroups(current => {
+            const next = { ...current };
+            delete next[group.id];
+            return next;
+        });
+
+        setSelectedEvents(current =>
+            current.filter(selected =>
+                !group.events.some(grouped =>
+                    songEventKey(grouped.game, grouped.event) === selected
+                )
+            )
+        );
+    }, [patchSettings]);
+
+    const removeAll = useCallback(() => {
+        patchSettings({
+            plando: {
+                songEvents: {
+                    ...(settings.songEventsShuffleOot ? { oot: null } : {}),
+                    ...(settings.songEventsShuffleMm ? { mm: null } : {}),
+                },
+            },
+        });
+
+        setSelectedEvents([]);
+        setSongEventGroups({});
+    }, [
+        patchSettings,
+        settings.songEventsShuffleOot,
+        settings.songEventsShuffleMm,
+    ]);
+
+    const groupedEventKeys = useMemo(() => {
+        const keys = new Set<string>();
+
+        for (const group of Object.values(songEventGroups || {})) {
+            if (!group) {
+                continue;
+            }
+
+            for (const event of group.events) {
+                keys.add(songEventKey(event.game, event.event));
+            }
+        }
+
+        for (const [event, data] of Object.entries(plando.songEvents?.oot || {}) as Array<[string, PlandoSongEventValue]>) {
+            if (data?.group) {
+                keys.add(songEventKey('oot', event));
+            }
+        }
+
+        for (const [event, data] of Object.entries(plando.songEvents?.mm || {}) as Array<[string, PlandoSongEventValue]>) {
+            if (data?.group) {
+                keys.add(songEventKey('mm', event));
+            }
+        }
+
+        return keys;
+    }, [
+        plando.songEvents,
+        songEventGroups,
+    ]);
+
+    const groups = useMemo(() => {
+        return Object.values(songEventGroups || {})
+            .filter((group): group is SongEventGroup => !!group)
+            .sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
+    }, [songEventGroups]);
+
+    const entries = useMemo(() => {
+        const next: Array<{
+            game: Game;
+            event: string;
+            song: PlandoSongEventSong;
+        }> = [];
+
+        if (settings.songEventsShuffleOot) {
+            next.push(...Object.entries(plando.songEvents?.oot || {})
+                .filter((x): x is [string, PlandoSongEventValue] => !!x[1])
+                .filter(([event]) => !groupedEventKeys.has(songEventKey('oot', event)))
+                .map(([event, data]) => ({
+                    game: 'oot' as const,
+                    event,
+                    song: data.song,
+                })));
+        }
+
+        if (settings.songEventsShuffleMm) {
+            next.push(...Object.entries(plando.songEvents?.mm || {})
+                .filter((x): x is [string, PlandoSongEventValue] => !!x[1])
+                .filter(([event]) => !groupedEventKeys.has(songEventKey('mm', event)))
+                .map(([event, data]) => ({
+                    game: 'mm' as const,
+                    event,
+                    song: data.song,
+                })));
+        }
+
+        return next.sort((a, b) => {
+            const ga = a.game.localeCompare(b.game);
+            return ga !== 0 ? ga : a.event.localeCompare(b.event);
+        });
+    }, [
+        groupedEventKeys,
+        plando.songEvents,
+        settings.songEventsShuffleOot,
+        settings.songEventsShuffleMm,
+    ]);
+
+    const hasItems = groups.length > 0 || entries.length > 0;
+
+    return (
+        <main className="h-full min-h-0 flex flex-col">
+            <nav className="flex gap-2">
+                <div className="flex-1">
+                    <Select
+                        searcheable
+                        placeholder="Song"
+                        options={songOptions}
+                        onSelect={setSelectedSong}
+                        value={selectedSong}
+                    />
+                </div>
+
+                <div className="flex-1">
+                    <MultiSelect
+                        searcheable
+                        placeholder="Song Event"
+                        options={eventOptions.map(option => ({
+                            value: option.key,
+                            label: option.label,
+                        }))}
+                        value={selectedEvents}
+                        onSelect={event => {
+                            setSelectedEvents(current =>
+                                current.includes(event) ? current : [...current, event]
+                            );
+                        }}
+                        onUnselect={event => {
+                            setSelectedEvents(current =>
+                                current.filter(x => x !== event)
+                            );
+                        }}
+                        onClear={() => setSelectedEvents([])}
+                    />
+                </div>
+
+                <Button onClick={placeSongEvent}>Add</Button>
+                <Button variant="danger" onClick={removeAll}>Remove All</Button>
+            </nav>
+
+            <Card className="flex-1 min-h-0 overflow-y-auto mt-4 gap-0">
+                {!hasItems && (
+                    <div className="flex items-center justify-center h-full">
+                        <span className="text-gray-500 text-3xl">
+                            No Song Event Items
+                        </span>
+                    </div>
+                )}
+
+                {groups.map(group => (
+                    <div
+                        key={group.id}
+                        className="shrink-0 mb-3 rounded border dark:border-gray-600 overflow-hidden"
+                    >
+                        <div className="ux-bg ux-border-b flex items-center gap-2 p-2 font-semibold">
+                            <span
+                                className="hover:text-gray-500 cursor-pointer"
+                                onClick={() => removeGroup(group)}
+                            >
+                                <FaXmark />
+                            </span>
+
+                            <span>{group.label}</span>
+
+                            <span className="text-gray-500 font-normal">
+                                {group.song === RANDOM_SONG_EVENT_SONG
+                                    ? 'Random'
+                                    : songEventSongName(Number(group.song))}
+                            </span>
+                        </div>
+
+                        <div className="flex flex-col">
+                            {group.events.map(({ game, event }) => (
+                                <div
+                                    key={`${group.id}:${game}:${event}`}
+                                    className="flex items-center gap-2 px-8 py-1.5 text-sm border-t dark:border-gray-700 first:border-t-0"
+                                >
+                                    <span>
+                                        {game.toUpperCase()} - {songEventLabel(event)}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ))}
+
+                {entries.map(({ game, event, song }) => (
+                    <div key={`${game}:${event}`} className="shrink-0 flex items-center gap-1">
+                        <span
+                            className="hover:text-gray-500 cursor-pointer"
+                            onClick={() => removeSongEvent(game, event)}
+                        >
+                            <FaXmark />
+                        </span>
+
+                        <span>
+                            {formatPlandoSong(song)}: {game.toUpperCase()} - {songEventLabel(event)}
+                        </span>
+                    </div>
+                ))}
+            </Card>
+        </main>
+    );
+}

--- a/packages/gui/src/app/components/generator/GeneratorAdvanced.tsx
+++ b/packages/gui/src/app/components/generator/GeneratorAdvanced.tsx
@@ -1,21 +1,24 @@
 import type { TabViewRoute } from '../nav';
 
-import { LuLightbulb, LuWrench } from 'react-icons/lu';
+import { LuLightbulb, LuWrench, LuMusic } from 'react-icons/lu';
 
 import { TabView } from '../nav';
 import { Hints } from '../Hints';
 import { Plando } from '../Plando';
+import { SongEventPlando } from '../SongEventPlando';
 import { useStore } from '@/app/store';
 
 export function GeneratorAdvanced() {
   const mode = useStore(state => state.config.mode);
+  const settings = useStore(state => state.settings);
   const isRandom = mode === 'random';
+  const hasSongEventPlando = settings.songEventsShuffleOot || settings.songEventsShuffleMm;
   const routes: TabViewRoute[] = [
     { name: 'Hints', icon: LuLightbulb, component: Hints },
-    { name: 'Plando', icon: LuWrench, component: Plando, disabled: isRandom },
+    { name: 'Plando', icon: LuWrench, component: Plando, disabled: isRandom }, ...(hasSongEventPlando ? [{ name: 'Song Event Plando', icon: LuMusic, component: SongEventPlando, disabled: isRandom }] : []),
   ];
 
   return (
-    <TabView routes={routes}/>
+      <TabView routes={routes}/>
   );
 }

--- a/packages/gui/src/app/components/ui/MultiSelect.tsx
+++ b/packages/gui/src/app/components/ui/MultiSelect.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState } from 'react';
+import { LuChevronDown } from 'react-icons/lu';
+import { FaXmark } from 'react-icons/fa6';
+import clsx from 'clsx';
+
+export type MultiSelectOption<T> = {
+  value: T;
+  label: string;
+};
+
+type MultiSelectProps<T> = {
+  id?: string;
+  options: MultiSelectOption<T>[];
+  value: T[];
+  placeholder?: string;
+  clearable?: boolean;
+  creatable?: boolean;
+  searcheable?: boolean;
+  onSelect: (value: T) => void;
+  onUnselect?: (value: T) => void;
+  onClear?: () => void;
+  onCreate?: (label: string) => void;
+};
+
+export function MultiSelect<T>({
+                                 id,
+                                 options,
+                                 value,
+                                 placeholder = '-----',
+                                 clearable,
+                                 creatable,
+                                 searcheable,
+                                 onSelect,
+                                 onUnselect,
+                                 onClear,
+                                 onCreate,
+                               }: MultiSelectProps<T>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+
+  const selectedOptions = options.filter((opt) => value.includes(opt.value));
+
+  const displayLabel =
+      selectedOptions.length === 1
+          ? selectedOptions[0].label
+          : selectedOptions.length > 1
+              ? `${selectedOptions.length} Events Selected`
+              : '';
+
+  const isSelected = (optionValue: T) => value.includes(optionValue);
+
+  const handleToggleOption = (optionValue: T) => {
+    if (isSelected(optionValue)) {
+      onUnselect?.(optionValue);
+    } else {
+      onSelect(optionValue);
+    }
+
+    setInputValue('');
+    setOpen(true);
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && inputValue.trim() && creatable) {
+      e.preventDefault();
+
+      onCreate?.(inputValue.trim());
+
+      setInputValue('');
+      setOpen(true);
+    }
+  };
+
+  const filterFunc = (opt: MultiSelectOption<T>) => {
+    if (!searcheable) return true;
+
+    return opt.label.toLowerCase().includes(inputValue.toLowerCase());
+  };
+
+  const onFocus = () => {
+    setOpen(true);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setInputValue('');
+      }
+    };
+
+    document.addEventListener('mousedown', onClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+    };
+  }, [open]);
+
+  const filteredOptions = options.filter(filterFunc);
+
+  return (
+      <div ref={containerRef}>
+        <div
+            className="ux-bg ux-border ux-hover flex items-center p-2"
+            onClick={() => {
+              setOpen(true);
+              inputRef.current?.focus();
+            }}
+        >
+          <div className="flex-1">
+            {open && (creatable || searcheable) ? (
+                <input
+                    ref={inputRef}
+                    type="text"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    id={id}
+                    placeholder={displayLabel || placeholder}
+                    className="w-full outline-none text-left select-none bg-transparent"
+                    value={inputValue}
+                    onFocus={onFocus}
+                    onInput={(e) => {
+                      setInputValue((e.target as HTMLInputElement).value);
+                    }}
+                    onKeyDown={onInputKeyDown}
+                />
+            ) : (
+                <div
+                    className={clsx(
+                        'outline-none text-left select-none',
+                        displayLabel ? '' : 'text-gray-500',
+                    )}
+                >
+                  {displayLabel || placeholder}
+                </div>
+            )}
+          </div>
+
+          {clearable && value.length > 0 && (
+              <div
+                  className="mr-1 dark:hover:text-gray-400 cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClear?.();
+                    setInputValue('');
+                  }}
+              >
+                <FaXmark />
+              </div>
+          )}
+
+          <div className="border-l dark:border-gray-500 pl-1">
+            <LuChevronDown size={20} />
+          </div>
+        </div>
+
+        <div className="relative select-none">
+          {open && (
+              <div className="ux-bg ux-border z-50 absolute top-1 dark:bg-gray-600 rounded border dark:border-gray-500 w-full max-h-[300px] overflow-y-auto">
+                {filteredOptions.length > 0 &&
+                    filteredOptions.map((opt, i) => {
+                      const checked = isSelected(opt.value);
+
+                      return (
+                          <div
+                              key={i}
+                              className="ux-hover p-2 flex items-center gap-2 cursor-pointer"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                handleToggleOption(opt.value);
+                              }}
+                          >
+                            <input
+                                type="checkbox"
+                                checked={checked}
+                                readOnly
+                                className="cursor-pointer"
+                            />
+
+                            <span>{opt.label}</span>
+                          </div>
+                      );
+                    })}
+
+                {filteredOptions.length === 0 && (
+                    <div className="p-8 text-gray-500">Nothing</div>
+                )}
+              </div>
+          )}
+        </div>
+      </div>
+  );
+}

--- a/packages/gui/src/app/components/ui/index.ts
+++ b/packages/gui/src/app/components/ui/index.ts
@@ -6,6 +6,7 @@ export * from './Tooltip';
 export * from './FileSelect';
 export * from './FileSelectField';
 export * from './Select';
+export * from './MultiSelect';
 export * from './Input';
 export * from './InputField';
 export * from './RadioCardGroup';

--- a/packages/logic/src/misc/song-events.ts
+++ b/packages/logic/src/misc/song-events.ts
@@ -1,7 +1,14 @@
 import type { Settings } from '@ootmm/core';
 import type { World } from '../world';
 
-import { Random, sample, SongEventSongs } from '@ootmm/core';
+import {
+  Random,
+  sample,
+  SongEventSongs,
+  SONG_EVENT_INDEX_OOT,
+  SONG_EVENT_INDEX_MM,
+  type PlandoSongEvents,
+} from '@ootmm/core';
 
 type LogicPassSongEventsState = {
   settings: Settings,
@@ -9,13 +16,26 @@ type LogicPassSongEventsState = {
   random: Random,
 };
 
+type Game = 'oot' | 'mm';
+
+type SongPools = Record<Game, number[]>;
+
+type RandomSongEventEntry = {
+  game: Game,
+  event: string,
+  index: number,
+  worldEvents: number[],
+};
+
+type PlandoSongEventsForGame = PlandoSongEvents[Game];
+
 class LogicPassSongEvents {
   constructor(
-    private readonly state: LogicPassSongEventsState,
+      private readonly state: LogicPassSongEventsState,
   ) {
   }
 
-  private shuffleSongEventsOot(world: World) {
+  private songCheckIdsOot() {
     const songCheckIds = [
       SongEventSongs.ZELDAS_LULLABY,
       SongEventSongs.EPONAS,
@@ -54,13 +74,10 @@ class LogicPassSongEvents {
     if (this.state.settings.songOrderOot) {
       songCheckIds.push(SongEventSongs.OATH);
     }
-    for (let i = 0; i < world.songEventsOot.length; ++i) {
-      const v = sample(this.state.random, songCheckIds);
-      world.songEventsOot[i] = v;
-    }
+    return songCheckIds;
   }
 
-  private shuffleSongEventsMm(world: World) {
+  private songCheckIdsMm() {
     const songCheckIds = [
       SongEventSongs.TIME,
       SongEventSongs.HEALING,
@@ -103,23 +120,153 @@ class LogicPassSongEvents {
     if (this.state.settings.songPreludeMm) {
       songCheckIds.push(SongEventSongs.PRELUDE);
     }
+    return songCheckIds;
+  }
+
+  private shuffleSongEventsOot(world: World, songCheckIds: number[]) {
+    for (let i = 0; i < world.songEventsOot.length; ++i) {
+      const v = sample(this.state.random, songCheckIds);
+      world.songEventsOot[i] = v;
+    }
+  }
+
+  private shuffleSongEventsMm(world: World, songCheckIds: number[]) {
     for (let i = 0; i < world.songEventsMm.length; ++i) {
       const v = sample(this.state.random, songCheckIds);
       world.songEventsMm[i] = v;
     }
   }
 
-  run() {
-    if (this.state.settings.songEventsShuffleOot) {
-      for (const world of this.state.worlds) {
-        this.shuffleSongEventsOot(world);
+  private collectPlandoSongEvents(
+      randomGroups: Map<string, RandomSongEventEntry[]>,
+      worldEvents: number[],
+      plando: PlandoSongEventsForGame,
+      eventIndex: Record<string, number>,
+      allowedSongs: Set<number>,
+      game: Game,
+  ) {
+    for (const [event, data] of Object.entries(plando)) {
+      if (!data) {
+        continue;
       }
+
+      const index = eventIndex[event];
+
+      if (index === undefined) {
+        throw new Error(`Invalid plando song event: ${event}`);
+      }
+
+      if (data.song === 'random') {
+        const group =
+            typeof data.group === 'string' && data.group.length > 0
+                ? data.group
+                : `${game}:${event}`;
+
+        const entries = randomGroups.get(group) ?? [];
+        entries.push({ game, event, index, worldEvents });
+        randomGroups.set(group, entries);
+
+        continue;
+      }
+
+      if (!allowedSongs.has(data.song)) {
+        throw new Error(`Invalid plando song for ${event}: ${data.song}`);
+      }
+
+      worldEvents[index] = data.song;
+    }
+  }
+
+  private randomPoolForGroup(
+      group: string,
+      entries: RandomSongEventEntry[],
+      pools: SongPools,
+  ) {
+    const games = new Set(entries.map(({ game }) => game));
+
+    if (games.has('oot') && games.has('mm')) {
+      const mmPool = new Set(pools.mm);
+      return pools.oot.filter(song => mmPool.has(song));
+    }
+
+    if (games.has('oot')) {
+      return pools.oot;
+    }
+
+    if (games.has('mm')) {
+      return pools.mm;
+    }
+
+    throw new Error(`Invalid empty random song event group: ${group}`);
+  }
+
+  private applyRandomSongGroups(
+      randomGroups: Map<string, RandomSongEventEntry[]>,
+      pools: SongPools,
+  ) {
+    for (const [group, entries] of randomGroups) {
+      const pool = this.randomPoolForGroup(group, entries, pools);
+
+      if (pool.length === 0) {
+        throw new Error(`No valid songs available for random song event group: ${group}`);
+      }
+
+      const resolvedSong = sample(this.state.random, pool);
+
+      for (const { worldEvents, index } of entries) {
+        worldEvents[index] = resolvedSong;
+      }
+    }
+  }
+
+  private applyPlandoSongEvents(world: World, pools: SongPools) {
+    const randomGroups = new Map<string, RandomSongEventEntry[]>();
+    const allowedSongs = {
+      oot: new Set(pools.oot),
+      mm: new Set(pools.mm),
+    };
+
+    if (this.state.settings.songEventsShuffleOot) {
+      this.collectPlandoSongEvents(
+          randomGroups,
+          world.songEventsOot,
+          this.state.settings.plando.songEvents.oot,
+          SONG_EVENT_INDEX_OOT,
+          allowedSongs.oot,
+          'oot',
+      );
     }
 
     if (this.state.settings.songEventsShuffleMm) {
-      for (const world of this.state.worlds) {
-        this.shuffleSongEventsMm(world);
+      this.collectPlandoSongEvents(
+          randomGroups,
+          world.songEventsMm,
+          this.state.settings.plando.songEvents.mm,
+          SONG_EVENT_INDEX_MM,
+          allowedSongs.mm,
+          'mm',
+      );
+    }
+
+    this.applyRandomSongGroups(randomGroups, pools);
+  }
+
+  run() {
+    const pools = {
+      oot: this.songCheckIdsOot(),
+      mm: this.songCheckIdsMm(),
+    };
+
+    for (const world of this.state.worlds) {
+      if (this.state.settings.songEventsShuffleOot) {
+        this.shuffleSongEventsOot(world, pools.oot);
       }
+
+      if (this.state.settings.songEventsShuffleMm) {
+        this.shuffleSongEventsMm(world, pools.mm);
+      }
+
+      this.applyPlandoSongEvents(world, pools);
     }
 
     return {};


### PR DESCRIPTION
Song event shuffle plando

Features:

Allows to plando any song event as single plando, or group plando.

Random assignment: Mainly exists for groups so that you can make an entire group of events all have the same random song. Otherwise assigning it to a single song is the same as not assigning anything at all to the event in which case it will shuffle as normal.

Tab is hidden if no song event shuffle settings are on.

Songs and event hide dynamically based on what items are available so you won't be able to assign an item that doesn't exist in one game to an event in that game.

Not super happy with the tool tip location, but couldn't really find a better place for it, and I do think the clarification is needed.

<img width="2550" height="1260" alt="image" src="https://github.com/user-attachments/assets/2f24ba36-7cac-473f-8eaa-ef09873ab914" />

