### PR TITLE
More Kamaro Fixes

### DIFF
--- a/packages/generator/src/oot/actors/Item/Item_Kamaro.c
+++ b/packages/generator/src/oot/actors/Item/Item_Kamaro.c
@@ -244,6 +244,7 @@ static s32 Player_KamaroItemActionIsCrouchStabMeleeOoT(s32 itemAction)
     return (itemAction == PLAYER_IA_SWORD_MASTER) ||
            (itemAction == PLAYER_IA_SWORD_KOKIRI) ||
            (itemAction == PLAYER_IA_SWORD_BIGGORON) ||
+           (itemAction == PLAYER_IA_HAMMER) ||
            (itemAction == PLAYER_IA_DEKU_STICK);
 }
 


### PR DESCRIPTION
Allow hammer to trigger Kamaro ISG

Moved file to a location that makes more sense and renamed to Item_Kamaro.c so its more apparent that its item code.