### PR TITLE
QoL Setting: Bow and Slingshot break Beehives in OoT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add quality of life setting to allow bow and slingshot to break beehives in OoT.
 - Add hyper enemies/bosses to both games, making them twice as fast.
 - Add Telescope ER.
 - Add Fairy Slingshot to Majora's Mask

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -409,8 +409,9 @@
 "hookshot_anywhere": "can_hookshot && setting(hookshotAnywhereOot, logical)"
 "longshot_anywhere": "can_longshot && setting(hookshotAnywhereOot, logical)"
 "evade_gerudo": "can_use_bow || can_hookshot || has(GERUDO_CARD) || can_use_mask_stone"
-"break_hive_low": "can_collect_distance || has_bombs || (has_bombchu && trick(OOT_HIVE_BOMBCHU))"
-"break_hive_high": "can_collect_distance || (has_bombchu && trick(OOT_HIVE_BOMBCHU))"
+"break_hive_with_slingbow": "setting(bowSlingshotBreakHives) && (can_use_bow || can_use_slingshot)"
+"break_hive_low": "can_collect_distance || has_bombs || (has_bombchu && trick(OOT_HIVE_BOMBCHU)) || break_hive_with_slingbow"
+"break_hive_high": "can_collect_distance || (has_bombchu && trick(OOT_HIVE_BOMBCHU)) || break_hive_with_slingbow"
 
 # Events
 "ganon_trial_light": "!setting(ganonTrials, Light) || event(GANON_TRIAL_LIGHT)"

--- a/packages/core/src/settings/data.ts
+++ b/packages/core/src/settings/data.ts
@@ -3637,6 +3637,14 @@ export const SETTINGS = [{
   default: true,
   cond: hasOoT,
 }, {
+  key: 'bowSlingshotBreakHives',
+  name: 'Bow/Slingshot Break Hives',
+  category: 'main.qol',
+  type: 'boolean',
+  description: 'Allows the Bow and Slingshot to break beehives in OoT, matching MM behavior',
+  default: false,
+  cond: hasOoT,
+}, {
   key: 'critWiggleDisable',
   name: 'Disable Crit Wiggle',
   category: 'main.qol',

--- a/packages/generator/lib/combo/confvars.ts
+++ b/packages/generator/lib/combo/confvars.ts
@@ -289,6 +289,7 @@ export const CONFVARS = [
   'MM_TELESCOPE_ER',
   'OOT_HYPER_ENEMIES',
   'MM_HYPER_ENEMIES',
+  'OOT_BOW_SLINGSHOT_BREAK_HIVES',
 ] as const;
 
 export type Confvar = typeof CONFVARS[number];

--- a/packages/generator/lib/combo/randomizer/world-config.ts
+++ b/packages/generator/lib/combo/randomizer/world-config.ts
@@ -106,6 +106,7 @@ export function worldConfig(world: LogicResultWorld, settings: Settings): Set<Co
     OOT_AGELESS_STICKS: settings.agelessSticks,
     OOT_AGELESS_BOW: settings.agelessBow,
     OOT_AGELESS_SLINGSHOT: settings.agelessSlingshot,
+    OOT_BOW_SLINGSHOT_BREAK_HIVES: settings.bowSlingshotBreakHives,
     OOT_AGELESS_BOOTS: settings.agelessBoots,
     OOT_AGELESS_STRENGTH: settings.agelessStrength,
     OOT_AGELESS_SWORDS: settings.agelessSwords,

--- a/packages/generator/src/common/ovl/actors/Obj_Comb/Obj_Comb.c
+++ b/packages/generator/src/common/ovl/actors/Obj_Comb/Obj_Comb.c
@@ -236,9 +236,15 @@ void ObjComb_Wait(Actor_ObjComb* this, PlayState* play)
     }
 
     if (this->collider.base.acFlags & AC_HIT) {
+        u32 bounceFlags = DMG_HAMMER | DMG_ARROW | DMG_SLINGSHOT | DMG_DEKU_STICK;
+
         this->collider.base.acFlags &= ~AC_HIT;
         dmgFlags = this->collider.elements[0].base.acHitElem->atDmgInfo.dmgFlags;
-        if (dmgFlags & (DMG_HAMMER | DMG_ARROW | DMG_SLINGSHOT | DMG_DEKU_STICK))
+        if (Config_Flag(CFG_OOT_BOW_SLINGSHOT_BREAK_HIVES))
+        {
+            bounceFlags &= ~(DMG_ARROW | DMG_SLINGSHOT);
+        }
+        if (dmgFlags & bounceFlags)
         {
             this->unk_1B0 = 1500;
         }


### PR DESCRIPTION
This adds a QoL ability to break beehives with the slingshot or bow in OoT to mirror MM's behavior. It's added into logic via the two `break_hive_low` and `break_hive_high` macros which slingshot and bow can reach.

Let me know if there's anything I need to change or I have missed.