### PR TITLE
Additional Slingshot logic

### DIFF
--- a/data/world/mm/dungeons/pirate_fortress.yml
+++ b/data/world/mm/dungeons/pirate_fortress.yml
@@ -148,7 +148,7 @@
     "GLOBAL": "true"
     "Pirate Fortress Interior": "true"
   events:
-    FORTRESS_BEEHIVE: "has_arrows || can_use_deku_bubble"
+    FORTRESS_BEEHIVE: "has_arrows || can_use_deku_bubble || has_slingshot"
     ARROWS: "true"
   locations:
     "Pirate Fortress Interior Pot Beehive 1": "true"
@@ -160,7 +160,7 @@
     "GLOBAL": "true"
     "Pirate Fortress Interior": "true"
   events:
-    FORTRESS_BEEHIVE: "has_mask_stone && can_hookshot_short && (has_arrows || can_use_deku_bubble)"
+    FORTRESS_BEEHIVE: "has_mask_stone && can_hookshot_short && (has_arrows || can_use_deku_bubble || has_slingshot)"
     ZORA_EGGS_HOOKSHOT_ROOM: "can_hookshot_short && underwater_walking && event(FORTRESS_BEEHIVE)"
   locations:
     "Pirate Fortress Interior Hookshot": "event(FORTRESS_BEEHIVE)"

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -100,7 +100,7 @@
     "Woodfall Temple Main Water Room Ledge": "true"
     "Woodfall Temple Water Room Map Ledge": "has(MASK_DEKU) || can_hookshot || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || short_hook_anywhere || (has_hover_boots && (has_arrows || can_hookshot_short)) || (has_mask_goron && (has_hover_boots || can_hookshot_short)) || (enter_woodfall_temple_water && can_enter_water && is_child && (can_hookshot_short || (has_arrows && (has_weapon || has_mask_zora || has_mask_goron || has_sticks))))"
     "Woodfall Temple Water Room Upper Ledge": "(has_arrows && (has(MASK_DEKU) || has_hover_boots)) || short_hook_anywhere"
-    "Woodfall Temple Water Room Boss Key Ledge": "(has_arrows && has(MASK_DEKU)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || has_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
@@ -112,7 +112,7 @@
     "Woodfall Temple Map Room": "true"
     "Woodfall Temple Water Room Lower Ledge": "has(MASK_DEKU) || short_hook_anywhere || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_hover_boots || (can_use_nayru && can_swim) || (has_arrows && (has_mask_goron || (enter_woodfall_temple_water && can_enter_water && is_child)))"
     "Woodfall Temple Water Room Upper Ledge": "(has_arrows && (has(MASK_DEKU) || has_hover_boots)) || short_hook_anywhere"
-    "Woodfall Temple Water Room Boss Key Ledge": "(has_arrows && has(MASK_DEKU)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || has_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
@@ -223,7 +223,7 @@
     "Woodfall Temple Water Room Lower Ledge": "has_bombs || has_mask_goron || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_arrows || has_hover_boots || short_hook_anywhere || can_swim || can_use_ice_arrows"
     "Woodfall Temple Water Room Map Ledge": "has_bombs || has_mask_goron || has_hover_boots || can_use_ice_arrows || can_hookshot_short"
     "Woodfall Temple Bow Room": "true"
-    "Woodfall Temple Water Room Boss Key Ledge": "(has_arrows && has(MASK_DEKU)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || has_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || has_hover_boots || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"

--- a/data/world/mm/overworld/termina_field.yml
+++ b/data/world/mm/overworld/termina_field.yml
@@ -51,7 +51,7 @@
     "Termina Field Tall Grass Chest": "true"
     "Termina Field Tree Stump Chest": "can_hookshot_short || can_use_beans"
     "Termina Field Kamaro Mask": "soul_citizen && song_event(6) && midnight"
-    "Termina Field Pot": "can_use_beans || has_bow || can_hookshot || has_boomerang"
+    "Termina Field Pot": "can_use_beans || has_bow || has_slingshot || can_hookshot || has_boomerang"
     "Termina Field Grass Pack 01 Grass 01": "true"
     "Termina Field Grass Pack 01 Grass 02": "true"
     "Termina Field Grass Pack 01 Grass 03": "true"

--- a/data/world/mm/overworld/zora_cape.yml
+++ b/data/world/mm/overworld/zora_cape.yml
@@ -17,7 +17,7 @@
     "Zora Cape Pot Game": "soul_zora && is_day && (has_weapon || has_mask_zora || can_hookshot_short || has_bow)"
   locations:
     "Zora Cape Underwater Chest": "underwater_walking"
-    "Zora Cape Waterfall HP": "has_mask_zora || (has_iron_boots && has_tunic_zora && (has_arrows || (has_bombchu && trick(MM_CAPE_LIKE_LIKE_BOMBCHU)) || has_mask_blast))"
+    "Zora Cape Waterfall HP": "has_mask_zora || (has_iron_boots && has_tunic_zora && (has_arrows || has_slingshot || (has_bombchu && trick(MM_CAPE_LIKE_LIKE_BOMBCHU)) || has_mask_blast))"
     "Zora Cape Pot Near Beavers 1": "true"
     "Zora Cape Pot Near Beavers 2": "true"
     "Zora Cape Rock Water 1": "true"


### PR DESCRIPTION
Added more Slingshot logic where it is appropriate (should be the remaining cases not accounted for)

-Zora Cape Like Like (can be killed like with Bow)

-Woodfall Temple Boss Key Ledge

-Pirate's Fortress Interior Hookshot Room beehive

-Termina Field pillar pot