### PR TITLE
Slingshot logic adjustments

### DIFF
--- a/data/world/mm/dungeons/pirate_fortress.yml
+++ b/data/world/mm/dungeons/pirate_fortress.yml
@@ -148,7 +148,7 @@
     "GLOBAL": "true"
     "Pirate Fortress Interior": "true"
   events:
-    FORTRESS_BEEHIVE: "has_arrows || can_use_deku_bubble || has_slingshot"
+    FORTRESS_BEEHIVE: "has_arrows || can_use_deku_bubble"
     ARROWS: "true"
   locations:
     "Pirate Fortress Interior Pot Beehive 1": "true"
@@ -160,7 +160,7 @@
     "GLOBAL": "true"
     "Pirate Fortress Interior": "true"
   events:
-    FORTRESS_BEEHIVE: "has_mask_stone && can_hookshot_short && (has_arrows || can_use_deku_bubble || has_slingshot)"
+    FORTRESS_BEEHIVE: "has_mask_stone && can_hookshot_short && (has_arrows || can_use_deku_bubble)"
     ZORA_EGGS_HOOKSHOT_ROOM: "can_hookshot_short && underwater_walking && event(FORTRESS_BEEHIVE)"
   locations:
     "Pirate Fortress Interior Hookshot": "event(FORTRESS_BEEHIVE)"

--- a/data/world/mm/overworld/ikana_graveyard.yml
+++ b/data/world/mm/overworld/ikana_graveyard.yml
@@ -13,7 +13,7 @@
     "Beneath The Graveyard Night 2": "soul_stalchild && has(MASK_CAPTAIN) && is_night2"
     "Beneath The Graveyard Night 3": "soul_stalchild && has(MASK_CAPTAIN) && is_night3"
   locations:
-    "Ikana Graveyard Captain Mask": "soul_enemy(SOUL_ENEMY_CAPTAIN_KEETA) && event(KEETA_WOKEN) && has_arrows && can_fight"
+    "Ikana Graveyard Captain Mask": "soul_enemy(SOUL_ENEMY_CAPTAIN_KEETA) && event(KEETA_WOKEN) && (has_arrows || has_slingshot) && can_fight"
     "Ikana Graveyard Grass 1": "true"
     "Ikana Graveyard Grass 2": "true"
     "Ikana Graveyard Grass 3": "true"


### PR DESCRIPTION
-Removed Slingshot logic for Pirate's Fortress Hive because the collision apparently doesn't allow for the projectile to go through the bars. TODO: Add a logic trick to hit the hive with Stone Mask from the Zora Egg Tank

-Added Slingshot logic to Captain Keeta as per Bryant it is a pain to adjust it to NOT stun Captain Keeta.