### PR TITLE
Adjusted previous slingshot logic additions

### DIFF
--- a/data/world/mm/dungeons/moon.yml
+++ b/data/world/mm/dungeons/moon.yml
@@ -173,7 +173,7 @@
   region: MOON
   exits:
     "Moon Trial Link Rest 2": "soul_iron_knuckle && (has_weapon || has_mask_goron || has_bombs || has_bombchu || (has_mask_blast && masks(5)))"
-    "Moon Trial Link Rest 3": "soul_iron_knuckle && (has_weapon || has_mask_goron || has_bombs || has_bombchu || (has_mask_blast && masks(5))) && ((has_bombchu && has_arrows) || short_hook_anywhere)"
+    "Moon Trial Link Rest 3": "soul_iron_knuckle && (has_weapon || has_mask_goron || has_bombs || has_bombchu || (has_mask_blast && masks(5))) && ((has_bombchu && (has_arrows || can_use_slingshot)) || short_hook_anywhere)"
   locations:
     "Moon Trial Link Iron Knuckle Chest": "soul_iron_knuckle && (has_weapon || has_mask_goron || has_bombs || has_bombchu || (has_mask_blast && masks(5)))"
   gossip:

--- a/data/world/mm/dungeons/moon.yml
+++ b/data/world/mm/dungeons/moon.yml
@@ -177,8 +177,8 @@
   locations:
     "Moon Trial Link Iron Knuckle Chest": "soul_iron_knuckle && (has_weapon || has_mask_goron || has_bombs || has_bombchu || (has_mask_blast && masks(5)))"
   gossip:
-    "Moon Trial Link Gossip Left": "short_hook_anywhere || (has_bombchu && has_arrows)"
-    "Moon Trial Link Gossip Right": "short_hook_anywhere || (has_bombchu && has_arrows)"
+    "Moon Trial Link Gossip Left": "short_hook_anywhere || (has_bombchu && (has_arrows || can_use_slingshot))"
+    "Moon Trial Link Gossip Right": "short_hook_anywhere || (has_bombchu && (has_arrows || can_use_slingshot))"
 
 "Moon Trial Link Rest 3":
   region: MOON

--- a/data/world/mm/dungeons/pirate_fortress.yml
+++ b/data/world/mm/dungeons/pirate_fortress.yml
@@ -160,7 +160,7 @@
     "GLOBAL": "true"
     "Pirate Fortress Interior": "true"
   events:
-    FORTRESS_BEEHIVE: "has_mask_stone && can_hookshot_short && (has_arrows || can_use_deku_bubble)"
+    FORTRESS_BEEHIVE: "has_mask_stone && can_hookshot_short && (has_arrows || can_use_deku_bubble || can_use_slingshot)"
     ZORA_EGGS_HOOKSHOT_ROOM: "can_hookshot_short && underwater_walking && event(FORTRESS_BEEHIVE)"
   locations:
     "Pirate Fortress Interior Hookshot": "event(FORTRESS_BEEHIVE)"

--- a/data/world/mm/dungeons/woodfall_temple.yml
+++ b/data/world/mm/dungeons/woodfall_temple.yml
@@ -100,7 +100,7 @@
     "Woodfall Temple Main Water Room Ledge": "true"
     "Woodfall Temple Water Room Map Ledge": "has(MASK_DEKU) || can_hookshot || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || short_hook_anywhere || (has_hover_boots && (has_arrows || can_hookshot_short)) || (has_mask_goron && (has_hover_boots || can_hookshot_short)) || (enter_woodfall_temple_water && can_enter_water && is_child && (can_hookshot_short || (has_arrows && (has_weapon || has_mask_zora || has_mask_goron || has_sticks))))"
     "Woodfall Temple Water Room Upper Ledge": "(has_arrows && (has(MASK_DEKU) || has_hover_boots)) || short_hook_anywhere"
-    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || has_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || can_use_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
@@ -112,7 +112,7 @@
     "Woodfall Temple Map Room": "true"
     "Woodfall Temple Water Room Lower Ledge": "has(MASK_DEKU) || short_hook_anywhere || can_use_ice_arrows || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_hover_boots || (can_use_nayru && can_swim) || (has_arrows && (has_mask_goron || (enter_woodfall_temple_water && can_enter_water && is_child)))"
     "Woodfall Temple Water Room Upper Ledge": "(has_arrows && (has(MASK_DEKU) || has_hover_boots)) || short_hook_anywhere"
-    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || has_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || can_use_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"
@@ -223,7 +223,7 @@
     "Woodfall Temple Water Room Lower Ledge": "has_bombs || has_mask_goron || event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_arrows || has_hover_boots || short_hook_anywhere || can_swim || can_use_ice_arrows"
     "Woodfall Temple Water Room Map Ledge": "has_bombs || has_mask_goron || has_hover_boots || can_use_ice_arrows || can_hookshot_short"
     "Woodfall Temple Bow Room": "true"
-    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || has_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
+    "Woodfall Temple Water Room Boss Key Ledge": "(has(MASK_DEKU) && (has_arrows || can_use_slingshot)) || (short_hook_anywhere && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || hookshot_anywhere"
     "WARP_SONGS": "true"
   locations:
     "Woodfall Temple Water Chest": "has(MASK_DEKU) || has_hover_boots || can_hookshot || (can_hookshot_short && (event(WOODFALL_TEMPLE_MAIN_FLOWER) || has_bombs || has_mask_goron)) || can_use_ice_arrows"

--- a/data/world/mm/overworld/ikana_graveyard.yml
+++ b/data/world/mm/overworld/ikana_graveyard.yml
@@ -13,7 +13,7 @@
     "Beneath The Graveyard Night 2": "soul_stalchild && has(MASK_CAPTAIN) && is_night2"
     "Beneath The Graveyard Night 3": "soul_stalchild && has(MASK_CAPTAIN) && is_night3"
   locations:
-    "Ikana Graveyard Captain Mask": "soul_enemy(SOUL_ENEMY_CAPTAIN_KEETA) && event(KEETA_WOKEN) && (has_arrows || has_slingshot) && can_fight"
+    "Ikana Graveyard Captain Mask": "soul_enemy(SOUL_ENEMY_CAPTAIN_KEETA) && event(KEETA_WOKEN) && (has_arrows || can_use_slingshot) && can_fight"
     "Ikana Graveyard Grass 1": "true"
     "Ikana Graveyard Grass 2": "true"
     "Ikana Graveyard Grass 3": "true"

--- a/data/world/mm/overworld/termina_field.yml
+++ b/data/world/mm/overworld/termina_field.yml
@@ -51,7 +51,7 @@
     "Termina Field Tall Grass Chest": "true"
     "Termina Field Tree Stump Chest": "can_hookshot_short || can_use_beans"
     "Termina Field Kamaro Mask": "soul_citizen && song_event(6) && midnight"
-    "Termina Field Pot": "can_use_beans || has_bow || has_slingshot || can_hookshot || has_boomerang"
+    "Termina Field Pot": "can_use_beans || has_bow || can_use_slingshot || can_hookshot || has_boomerang"
     "Termina Field Grass Pack 01 Grass 01": "true"
     "Termina Field Grass Pack 01 Grass 02": "true"
     "Termina Field Grass Pack 01 Grass 03": "true"

--- a/data/world/mm/overworld/zora_cape.yml
+++ b/data/world/mm/overworld/zora_cape.yml
@@ -17,7 +17,7 @@
     "Zora Cape Pot Game": "soul_zora && is_day && (has_weapon || has_mask_zora || can_hookshot_short || has_bow)"
   locations:
     "Zora Cape Underwater Chest": "underwater_walking"
-    "Zora Cape Waterfall HP": "has_mask_zora || (has_iron_boots && has_tunic_zora && (has_arrows || has_slingshot || (has_bombchu && trick(MM_CAPE_LIKE_LIKE_BOMBCHU)) || has_mask_blast))"
+    "Zora Cape Waterfall HP": "has_mask_zora || (has_iron_boots && has_tunic_zora && (has_arrows || can_use_slingshot || (has_bombchu && trick(MM_CAPE_LIKE_LIKE_BOMBCHU)) || has_mask_blast))"
     "Zora Cape Pot Near Beavers 1": "true"
     "Zora Cape Pot Near Beavers 2": "true"
     "Zora Cape Rock Water 1": "true"


### PR DESCRIPTION
This PR is just to change all the previous logic additions I made from has_slingshot to can_use_slingshot. Also, added Slingshot logic to the one Eye Switch on the Moon. Re-added the PFI section I took out because it, indeed, is in base logic lol. It just couldn't be for the upper room (I had both before, I only needed to take out the upper)