### PR TITLE
Ghost Hut HP Slingshot Logic

### DIFF
--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -390,7 +390,7 @@
 #"can_kill_invisible_enemies": "can_use_lens" #Enemizer or Actorizer might make this macro relevant for switching enemies.
 
 #MM Bosses:
-"can_kill_odolwa": "soul_boss(SOUL_BOSS_ODOLWA) && ((has(MASK_FIERCE_DEITY) && has_magic) || (has_arrows || can_use_slingshot) && can_fight))"  # Add trick for without arrows to stun. Add a trick for bomb flowers to stun.
+"can_kill_odolwa": "soul_boss(SOUL_BOSS_ODOLWA) && ((has(MASK_FIERCE_DEITY) && has_magic) || ((has_arrows || can_use_slingshot) && can_fight))"  # Add trick for without arrows to stun. Add a trick for bomb flowers to stun.
 "can_kill_goht": "soul_boss(SOUL_BOSS_GOHT) && can_use_fire_short_range && (has_arrows || has_mask_goron || has(MASK_FIERCE_DEITY))"
 "can_kill_gyorg": "soul_boss(SOUL_BOSS_GYORG) && ((has_magic && ((has_mask_zora && has_arrows) || has(MASK_FIERCE_DEITY))) || (has_iron_boots && has_tunic_zora_strict && can_hookshot_short && trick(MM_GYORG_IRONS)))"
 "can_kill_twinmold": "soul_boss(SOUL_BOSS_TWINMOLD) && ((trick(MM_TWINMOLD_BOW) && has_arrows) || (trick(MM_TWINMOLD_FIRE_AND_ICE) && can_use_fire_arrows && can_use_ice_arrows) || (has_magic && ((has(MASK_GIANT) && has_sword) || has(MASK_FIERCE_DEITY))))"

--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -390,7 +390,7 @@
 #"can_kill_invisible_enemies": "can_use_lens" #Enemizer or Actorizer might make this macro relevant for switching enemies.
 
 #MM Bosses:
-"can_kill_odolwa": "soul_boss(SOUL_BOSS_ODOLWA) && ((has(MASK_FIERCE_DEITY) && has_magic) || (has_arrows && can_fight))"  # Add trick for without arrows to stun. Add a trick for bomb flowers to stun.
+"can_kill_odolwa": "soul_boss(SOUL_BOSS_ODOLWA) && ((has(MASK_FIERCE_DEITY) && has_magic) || (has_arrows || can_use_slingshot) && can_fight)))"  # Add trick for without arrows to stun. Add a trick for bomb flowers to stun.
 "can_kill_goht": "soul_boss(SOUL_BOSS_GOHT) && can_use_fire_short_range && (has_arrows || has_mask_goron || has(MASK_FIERCE_DEITY))"
 "can_kill_gyorg": "soul_boss(SOUL_BOSS_GYORG) && ((has_magic && ((has_mask_zora && has_arrows) || has(MASK_FIERCE_DEITY))) || (has_iron_boots && has_tunic_zora_strict && can_hookshot_short && trick(MM_GYORG_IRONS)))"
 "can_kill_twinmold": "soul_boss(SOUL_BOSS_TWINMOLD) && ((trick(MM_TWINMOLD_BOW) && has_arrows) || (trick(MM_TWINMOLD_FIRE_AND_ICE) && can_use_fire_arrows && can_use_ice_arrows) || (has_magic && ((has(MASK_GIANT) && has_sword) || has(MASK_FIERCE_DEITY))))"

--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -208,7 +208,7 @@
 "can_fight": "has_weapon || has_mask_zora || has_mask_goron"
 "has_shield": "renewable(SHIELD_HERO) || renewable(SHIELD_DEKU) || renewable(SHARED_SHIELD_DEKU) || renewable(SHARED_SHIELD_HYLIAN) || has(SHIELD, 1) || cond(setting(dekuShieldMm), has(SHARED_SHIELD, 1), has(SHARED_SHIELD, 2)) || has_mirror_shield"
 "can_activate_crystal": "can_break_boulders || has_weapon || has_arrows || can_hookshot_short || has(MASK_DEKU) || has_mask_zora || has_sticks"
-"can_evade_gerudo": "has_arrows || can_hookshot_short || has_mask_zora || has_mask_stone"
+"can_evade_gerudo": "has_arrows || can_use_slingshot || has_boomerang || can_hookshot_short || has_mask_zora || has_mask_stone"
 "can_goron_bomb_jump": "trick(MM_GORON_BOMB_JUMP) && has_mask_goron && (has_bombs || trick_keg_explosives)"
 "can_hookshot_n(x)": "has(HOOKSHOT, x) || has(SHARED_HOOKSHOT, x)"
 "can_hookshot_short": "can_hookshot_n(1)"

--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -390,7 +390,7 @@
 #"can_kill_invisible_enemies": "can_use_lens" #Enemizer or Actorizer might make this macro relevant for switching enemies.
 
 #MM Bosses:
-"can_kill_odolwa": "soul_boss(SOUL_BOSS_ODOLWA) && ((has(MASK_FIERCE_DEITY) && has_magic) || (has_arrows || can_use_slingshot) && can_fight)))"  # Add trick for without arrows to stun. Add a trick for bomb flowers to stun.
+"can_kill_odolwa": "soul_boss(SOUL_BOSS_ODOLWA) && ((has(MASK_FIERCE_DEITY) && has_magic) || (has_arrows || can_use_slingshot) && can_fight))"  # Add trick for without arrows to stun. Add a trick for bomb flowers to stun.
 "can_kill_goht": "soul_boss(SOUL_BOSS_GOHT) && can_use_fire_short_range && (has_arrows || has_mask_goron || has(MASK_FIERCE_DEITY))"
 "can_kill_gyorg": "soul_boss(SOUL_BOSS_GYORG) && ((has_magic && ((has_mask_zora && has_arrows) || has(MASK_FIERCE_DEITY))) || (has_iron_boots && has_tunic_zora_strict && can_hookshot_short && trick(MM_GYORG_IRONS)))"
 "can_kill_twinmold": "soul_boss(SOUL_BOSS_TWINMOLD) && ((trick(MM_TWINMOLD_BOW) && has_arrows) || (trick(MM_TWINMOLD_FIRE_AND_ICE) && can_use_fire_arrows && can_use_ice_arrows) || (has_magic && ((has(MASK_GIANT) && has_sword) || has(MASK_FIERCE_DEITY))))"

--- a/data/world/mm/overworld/ikana_valley.yml
+++ b/data/world/mm/overworld/ikana_valley.yml
@@ -125,7 +125,7 @@
     "GLOBAL": "true"
     "Ikana Canyon": "true"
   locations:
-    "Ghost Hut HP": "soul_poe_collector && soul_poe && (has_arrows || can_hookshot_short || can_use_deku_bubble) && can_use_wallet(1) && is_valley_cursed"
+    "Ghost Hut HP": "soul_poe_collector && soul_poe && (has_arrows || can_hookshot_short || can_use_slingshot || can_use_deku_bubble) && can_use_wallet(1) && is_valley_cursed"
 
 "Ikana Castle Entrance":
   region: IKANA_CASTLE


### PR DESCRIPTION
Just a simple logic add, since Slingshot does Deku Bubble damage it can work for Ghost Hut HP just like Deku Bubbles.

Edit: Also discovered that Slingshot stuns Odolwa and thus can be logical for him.

Edit 2: Realized I forgot Slingshot and Boomerang for can_evade_gerudo, tested to make sure Slingshot worked and it does.