### PR TITLE
Increase mm payload size

### DIFF
--- a/packages/generator/include/combo/defs.h
+++ b/packages/generator/include/combo/defs.h
@@ -35,7 +35,7 @@
 #endif
 
 #ifdef GAME_MM
-# define PAYLOAD_SIZE   0x50000
+# define PAYLOAD_SIZE   0x60000
 # define PAYLOAD_RAM    (0x80780000 - PAYLOAD_SIZE)
 # define HEAP_SIZE      0x40000
 # define HEAP_BASE      (PAYLOAD_RAM - HEAP_SIZE)

--- a/packages/generator/lib/combo/patch-build/index.ts
+++ b/packages/generator/lib/combo/patch-build/index.ts
@@ -121,11 +121,11 @@ export async function buildPatchfiles(args: BuildPatchfileIn): Promise<Patchfile
       }
       /* Pack the payload */
       const payload = await fileResolver.fetch(`${game}_payload.bin`);
-      if (payload.length > (game === 'mm' ? 0x50000 : 0x80000)) {
+      if (payload.length > (game === 'mm' ? 0x60000 : 0x80000)) {
         throw new Error(`Payload too large ${game}`);
       }
       const payloadVrom = game === 'oot' ? 0xf0000000 : 0xf0100000;
-      const payloadVram = game === 'oot' ? 0x80400000 : 0x80730000; /* TODO: Codegen this */
+      const payloadVram = game === 'oot' ? 0x80400000 : 0x80720000; /* TODO: Codegen this */
       const payloadVramEnd = payloadVram + payload.length;
       p.addNewFile({ name: `${game}/payload`, vrom: payloadVrom, vram: { [game]: [payloadVram, payloadVramEnd] }, data: payload, compressed: false });
 


### PR DESCRIPTION
Increase MM payload as we are at the ceiling and no extra mm side code can be added without this.