### PR TITLE
Minor fix to Spirit MQ logic

### DIFF
--- a/data/world/oot/dungeons_mq/spirit_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/spirit_temple_mq.yml
@@ -17,7 +17,7 @@
     "MQ Spirit Temple Compass Chest": "can_use_slingshot && has_bow && small_keys_spirit(2) && has_bombchu"
     "MQ Spirit Temple Sun Block Room Chest": "small_keys_spirit(2) && has_bombchu && (can_play_time || can_play_emptiness) && is_child"
     "MQ Spirit Temple Lobby Front-Right Chest": "silver_rupees_spirit_lobby"
-    "Spirit Temple Silver Gauntlets": "small_keys_spirit(4) && has_explosives && (can_play_time || can_play_emptiness) && is_child && soul_iron_knuckle && (has_weapon || can_use_sticks) && has_lens"
+    "Spirit Temple Silver Gauntlets": "small_keys_spirit(4) && has_bombchu && (can_play_time || can_play_emptiness) && is_child && soul_iron_knuckle && (has_weapon || can_use_sticks) && has_lens"
     "MQ Spirit Temple SR Lobby Rock Right": "has_explosives_or_hammer"
     "MQ Spirit Temple SR Lobby Rock Left": "has_explosives_or_hammer"
     "MQ Spirit Temple Pot Entrance 1": "true"


### PR DESCRIPTION
Weirdly, while nearly everything else in the dungeon is specifically bombchu locked, Silver Gauntlet chest only checks for any explosives. Technically Age Swap and Hammer through Walls also works as it does for most of the dungeon, but implementing that is above my pay grade.