### PR TITLE
Minor Logic Adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix logic for Secret Shrine Entrance Pots, and account for bronze scale logic for the underwater ones.
 - Fix logic for MM Termina Field Soil Observatory items not being in the right logic region.
 - Load Save screen properly lets you cycle to the next page if Only MM or Only OOT is on.
 - Fix Tatl sometimes crashing when you talk to her during 4th day.

--- a/data/macros/macros_mm.yml
+++ b/data/macros/macros_mm.yml
@@ -392,6 +392,6 @@
 #MM Bosses:
 "can_kill_odolwa": "soul_boss(SOUL_BOSS_ODOLWA) && ((has(MASK_FIERCE_DEITY) && has_magic) || ((has_arrows || can_use_slingshot) && can_fight))"  # Add trick for without arrows to stun. Add a trick for bomb flowers to stun.
 "can_kill_goht": "soul_boss(SOUL_BOSS_GOHT) && can_use_fire_short_range && (has_arrows || has_mask_goron || has(MASK_FIERCE_DEITY))"
-"can_kill_gyorg": "soul_boss(SOUL_BOSS_GYORG) && ((has_magic && ((has_mask_zora && has_arrows) || has(MASK_FIERCE_DEITY))) || (has_iron_boots && has_tunic_zora_strict && can_hookshot_short && trick(MM_GYORG_IRONS)))"
+"can_kill_gyorg": "soul_boss(SOUL_BOSS_GYORG) && ((has_magic && ((has_mask_zora && (has_arrows || can_use_slingshot)) || has(MASK_FIERCE_DEITY))) || (has_iron_boots && has_tunic_zora_strict && can_hookshot_short && trick(MM_GYORG_IRONS)))"
 "can_kill_twinmold": "soul_boss(SOUL_BOSS_TWINMOLD) && ((trick(MM_TWINMOLD_BOW) && has_arrows) || (trick(MM_TWINMOLD_FIRE_AND_ICE) && can_use_fire_arrows && can_use_ice_arrows) || (has_magic && ((has(MASK_GIANT) && has_sword) || has(MASK_FIERCE_DEITY))))"
 "can_kill_igos": "soul_boss(SOUL_BOSS_IGOS) && has_mirror_shield && (can_use_fire_arrows || (trick(MM_IGOS_DINS) && can_use_din)) && (can_fight || can_use_deku_bubble || can_use_slingshot)" #If action shuffle is ever a thing, this needs to be adjusted since Deku won't be able to spin to stun. We currently assume if they can deku bubble, they can spin to stun.

--- a/data/pool/pool_mm.csv
+++ b/data/pool/pool_mm.csv
@@ -2671,15 +2671,15 @@ Secret Shrine Wizzrobe Chest,                           chest,          NONE,   
 Secret Shrine Wart Chest,                               chest,          SECRET_SHRINE_WART_HP,  SECRET_SHRINE,                0x02,                       RUPEE_SILVER
 Secret Shrine Garo Master Chest,                        chest,          NONE,                   SECRET_SHRINE,                0x03,                       RUPEE_SILVER
 Secret Shrine HP Chest,                                 chest,          SECRET_SHRINE_WART_HP,  SECRET_SHRINE,                0x0a,                       HEART_PIECE
-Secret Shrine Pot 1,                                    pot,            NONE,                   SECRET_SHRINE,                0x0017,                     RECOVERY_HEART
-Secret Shrine Pot 2,                                    pot,            NONE,                   SECRET_SHRINE,                0x0018,                     ARROWS_10
-Secret Shrine Pot 3,                                    pot,            NONE,                   SECRET_SHRINE,                0x0019,                     MAGIC_JAR_SMALL
-Secret Shrine Pot 4,                                    pot,            NONE,                   SECRET_SHRINE,                0x0106,                     MAGIC_JAR_SMALL
-Secret Shrine Pot 5,                                    pot,            NONE,                   SECRET_SHRINE,                0x0107,                     RECOVERY_HEART
-Secret Shrine Pot 6,                                    pot,            NONE,                   SECRET_SHRINE,                0x0108,                     ARROWS_10
-Secret Shrine Pot 7,                                    pot,            NONE,                   SECRET_SHRINE,                0x0109,                     ARROWS_10
-Secret Shrine Pot 8,                                    pot,            NONE,                   SECRET_SHRINE,                0x010a,                     MAGIC_JAR_SMALL
-Secret Shrine Pot 9,                                    pot,            NONE,                   SECRET_SHRINE,                0x010b,                     FAIRY
+Secret Shrine Pot Entrance 1,                           pot,            NONE,                   SECRET_SHRINE,                0x0017,                     RECOVERY_HEART
+Secret Shrine Pot Entrance 2,                           pot,            NONE,                   SECRET_SHRINE,                0x0018,                     ARROWS_10
+Secret Shrine Pot Entrance 3,                           pot,            NONE,                   SECRET_SHRINE,                0x0019,                     MAGIC_JAR_SMALL
+Secret Shrine Pot Underwater 1,                         pot,            NONE,                   SECRET_SHRINE,                0x0106,                     MAGIC_JAR_SMALL
+Secret Shrine Pot Underwater 2,                         pot,            NONE,                   SECRET_SHRINE,                0x0107,                     RECOVERY_HEART
+Secret Shrine Pot Underwater 3,                         pot,            NONE,                   SECRET_SHRINE,                0x0108,                     ARROWS_10
+Secret Shrine Pot Underwater 4,                         pot,            NONE,                   SECRET_SHRINE,                0x0109,                     ARROWS_10
+Secret Shrine Pot Underwater 5,                         pot,            NONE,                   SECRET_SHRINE,                0x010a,                     MAGIC_JAR_SMALL
+Secret Shrine Pot Underwater 6,                         pot,            NONE,                   SECRET_SHRINE,                0x010b,                     FAIRY
 Secret Shrine Grass Entrance 1,                         grass,          NONE,                   SECRET_SHRINE,                0x0001a,                    RANDOM
 Secret Shrine Grass Entrance 2,                         grass,          NONE,                   SECRET_SHRINE,                0x0001b,                    RANDOM
 Secret Shrine Grass Entrance 3,                         grass,          NONE,                   SECRET_SHRINE,                0x0001c,                    RANDOM

--- a/data/world/mm/dungeons/secret_shrine.yml
+++ b/data/world/mm/dungeons/secret_shrine.yml
@@ -17,9 +17,9 @@
     "Secret Shrine Main": "can_use_light_arrows"
     "Secret Shrine Rupees": "can_use_beans || has_boomerang || has_mask_zora || hookshot_anywhere"
   locations:
-    "Secret Shrine Pot 1": "true"
-    "Secret Shrine Pot 2": "true"
-    "Secret Shrine Pot 3": "true"
+    "Secret Shrine Pot Entrance 1": "true"
+    "Secret Shrine Pot Entrance 2": "true"
+    "Secret Shrine Pot Entrance 3": "true"
     "Secret Shrine Grass Entrance 1": "true"
     "Secret Shrine Grass Entrance 2": "true"
     "Secret Shrine Grass Entrance 3": "true"
@@ -62,12 +62,12 @@
     "Secret Shrine Boss Garo Master": "true"
   locations:
     "Secret Shrine HP Chest": "soul_poe_collector && event(SECRET_SHRINE_DINOLFOS) && event(SECRET_SHRINE_WIZZROBE) && event(SECRET_SHRINE_WART) && event(SECRET_SHRINE_GARO)"
-    "Secret Shrine Pot 4": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
-    "Secret Shrine Pot 5": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
-    "Secret Shrine Pot 6": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
-    "Secret Shrine Pot 7": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
-    "Secret Shrine Pot 8": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
-    "Secret Shrine Pot 9": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot Underwater 1": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot Underwater 2": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot Underwater 3": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot Underwater 4": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot Underwater 5": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot Underwater 6": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
 
 "Secret Shrine Boss Dinolfos":
   dungeon: SS

--- a/data/world/mm/dungeons/secret_shrine.yml
+++ b/data/world/mm/dungeons/secret_shrine.yml
@@ -17,6 +17,9 @@
     "Secret Shrine Main": "can_use_light_arrows"
     "Secret Shrine Rupees": "can_use_beans || has_boomerang || has_mask_zora || hookshot_anywhere"
   locations:
+    "Secret Shrine Pot 1": "true"
+    "Secret Shrine Pot 2": "true"
+    "Secret Shrine Pot 3": "true"
     "Secret Shrine Grass Entrance 1": "true"
     "Secret Shrine Grass Entrance 2": "true"
     "Secret Shrine Grass Entrance 3": "true"
@@ -59,15 +62,12 @@
     "Secret Shrine Boss Garo Master": "true"
   locations:
     "Secret Shrine HP Chest": "soul_poe_collector && event(SECRET_SHRINE_DINOLFOS) && event(SECRET_SHRINE_WIZZROBE) && event(SECRET_SHRINE_WART) && event(SECRET_SHRINE_GARO)"
-    "Secret Shrine Pot 1": "true"
-    "Secret Shrine Pot 2": "true"
-    "Secret Shrine Pot 3": "true"
-    "Secret Shrine Pot 4": "true"
-    "Secret Shrine Pot 5": "true"
-    "Secret Shrine Pot 6": "true"
-    "Secret Shrine Pot 7": "true"
-    "Secret Shrine Pot 8": "true"
-    "Secret Shrine Pot 9": "true"
+    "Secret Shrine Pot 4": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot 5": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot 6": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot 7": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot 8": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
+    "Secret Shrine Pot 9": "has_mask_zora || (can_swim_or_sink && (has_arrows || can_hookshot_short || has_boomerang || can_use_slingshot))"
 
 "Secret Shrine Boss Dinolfos":
   dungeon: SS


### PR DESCRIPTION
-Added Slingshot to the Gyorg boss macro because it does, in fact, stun Gyorg like arrows do.

-Moved the first 3 Secret Shrine pots to the main lobby where they belong and *not* behind LAs

-Adjusted the other secret shrine pots to account for bronze scale logic, as in, you need the ability to swim or use iron boots to collect them once breaking them with a ranged weapon or zora mask.