### PR TITLE
Fix gfs/hammer oot

### DIFF
--- a/packages/generator/src/common/item/item_add.c
+++ b/packages/generator/src/common/item/item_add.c
@@ -174,6 +174,8 @@ static void reloadSlotEquipsOot(OotItemEquips* equips, int slot)
 void reloadSlotRawOot(int slot)
 {
     reloadSlotEquipsOot(&gOotSave.info.equips, slot);
+    if (slot == ITS_OOT_HAMMER)
+        return;
     reloadSlotEquipsOot(&gOotSave.info.childEquips, slot);
     reloadSlotEquipsOot(&gOotSave.info.adultEquips, slot);
 }


### PR DESCRIPTION
Fix bug with hammer and great fairy sword in OOT where if gfs is equipped on child c button and you go change to adult and equip hammer, going back to child will have hammer equipped instead of great fairy sword allowing child to use it without ageless hammer on (and vice versa with starting with adult and equipping hammer).