### PR TITLE
(web) Multiplayer guide: better specify how to launch the client

### DIFF
--- a/packages/web/src/content/Multiplayer.mdx
+++ b/packages/web/src/content/Multiplayer.mdx
@@ -40,7 +40,9 @@ Each player needs to get their patch file from the player that generated the mul
 
 To start playing and sending/receiving items, each player needs to do the following:
 
- * Drag and drop the patch file into the OoTMM Client (download link above)
+ * Launch the OoTMM Client (download link above):
+    * The first time you use the OoTMM Client, it must be launched by drag-and-dropping the patch file onto the program's icon. The OoTMM Client fails to launch when executed without a patch file.
+    * For subsequent uses, you may also launch the OoTMM Client simply by opening the patch file itself. 
  * Start Project64-EM
  * Open your multiplayer OoTMM ROM inside Project64-EM
 


### PR DESCRIPTION
This makes it clearer:
* that drag and drop is done to launch the client. It's not launch THEN drag and drop.
* that this is only needed the first time because file associations.