### PR TITLE
Reset sling shot ammo when item reset is off

### DIFF
--- a/packages/generator/src/mm/save.c
+++ b/packages/generator/src/mm/save.c
@@ -80,6 +80,7 @@ void Sram_SaveEndOfCycle(PlayState* play)
         /* Reset ammo */
         for (int i = 0; i < 24; ++i)
             gSave.info.inventory.ammo[i] = 0;
+        gMmExtraAmmo.slingshotSeeds = 0;
 
         /* Reset rupees */
         gSave.info.playerData.rupees = 0;


### PR DESCRIPTION
Fix slingshot seeds not resetting when keep items is off