### PR TITLE
Allow ageless fire arrows for  "Zora Domain Waterfall Chest"

### DIFF
--- a/data/world/oot/overworld/zora_domain.yml
+++ b/data/world/oot/overworld/zora_domain.yml
@@ -14,7 +14,7 @@
     RUPEES: "true"
     FISH: "is_child && has_bottle"
   locations:
-    "Zora Domain Waterfall Chest": "is_child && can_use_sticks"
+    "Zora Domain Waterfall Chest": "is_child && (can_use_sticks || has_fire_arrows)"
     "Zora Domain Diving Game": "is_child && can_use_wallet(1) && soul_zora && can_swim_or_sink"
     "Zora Domain Diving Game Green Rupee": "is_child && can_use_wallet(1) && soul_zora && can_swim_or_sink"
     "Zora Domain Diving Game Blue Rupee": "is_child && can_use_wallet(1) && soul_zora && can_swim_or_sink"


### PR DESCRIPTION
No need to add to changelog: this change is sorta implied by the addition of the stick bag.