### PR TITLE
Numerous Skulltula-related changes and additional fixes

### DIFF
--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -1,6 +1,8 @@
 #Generic Utility Macros
 "is_child": "age(child)"
 "is_adult": "age(adult)"
+"temp_flag_event(childEvent, adultEvent)": "(is_child && childEvent) || (is_adult && adultEvent)"
+#"temp_flag_event_time_travel(childEvent, adultEvent)": "temp_flag_event(childEvent, adultEvent) || time_travel_at_will && (childEvent || adultEvent)" # This macro is only relevant for sitations where Link moves from one place he can time travel to a place he may not (e.g.s; 1 - because of ER, 2 - through a door to a boss room)
 "has_clock": "setting(clocksOot, none) || has(CLOCK)"
 "is_day": "(has_clock || setting(clocksOot, day)) && (oot_time(day) || can_play_sun || can_play_double_time)"
 "is_night": "(has_clock || setting(clocksOot, night)) && (oot_time(night) || can_play_sun || can_play_double_time)"
@@ -231,13 +233,14 @@
 "can_hit_scrub": "has_nuts || can_hit_triggers_distance || has_shield_for_scrubs || can_collect_distance || can_hammer || has_explosives"
 "can_rescue_carpenter": "small_keys_hideout_all && (can_use_sword || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
 "carpenters_rescued": "setting(gerudoFortress, open) || (event(CARPENTER_1) && (setting(gerudoFortress, single) || (event(CARPENTER_2) && event(CARPENTER_3) && event(CARPENTER_4))))"
-"get_past_skultullas": "has_nuts || can_use_sword_or_sticks || has_ranged_weapon || can_use_din || has_explosives || can_hammer || can_use_mask_blast || can_use_mask_stone"
-"get_past_skultullas_no_stone": "has_nuts || can_use_sword_or_sticks || has_ranged_weapon || can_use_din || has_explosives || can_hammer || can_use_mask_blast"
+"get_past_skulltulas": "get_past_skulltulas_no_stone || can_use_mask_stone" #These both assume extreme close range
+"get_past_skulltulas_no_stone": "has_nuts || has_boomerang || can_kill_skulltulas || trick(GLITCH_OOT_SKULLTULA_ELEVATOR)"
 "collect_gs_on_walls": "gs && (can_collect_distance || (has_ranged_weapon && climb_anywhere))" #TODO: Low/high macros like beehives; Din's, Blast mask, bomchus, bombs (if within throwing distance) and maybe even jump slashes if space permits (and damage?)
 "can_carry_keg": "can_lift_gold"
 "can_use_keg": "can_carry_keg && cond(setting(sharedPowderKeg), event(MM_BUY_KEG) || event(BUY_KEG), setting(powderKegOot) && event(BUY_KEG))"
 "can_hit_crystal_switch_close": "has_weapon || has_bombs || can_use_mask_blast || has_bombchu || can_use_bow || can_use_slingshot || can_hookshot || can_use_sticks || can_hammer || can_boomerang"
-
+"break_icicle": "can_use_sword_or_sticks || has_explosives_or_hammer"
+"break_icicle_ice_cavern": "can_use_sword || has_explosives_or_hammer || (can_use_sticks && (trick(OOT_ICE_CAVERN_ICICLES_STICKS) || glitch_broken_stick))"
 
 #Trick Macros
 "has_lens": "has_lens_strict || trick(OOT_LENS)"
@@ -246,7 +249,7 @@
 # Mido / Deku Tree
 "can_move_mido_reqs": "is_child && has_sword_kokiri && has_shield_deku"
 "can_move_mido": "can_move_mido_reqs && soul_npc(SOUL_NPC_MIDO)"
-"can_bypass_mido": "setting(dekuTree, open) || is_adult || climb_anywhere || hookshot_anywhere || can_move_mido_reqs"
+"can_bypass_mido": "setting(dekuTree, open) || climb_anywhere || hookshot_anywhere || can_move_mido_reqs || is_adult && (get_past_skulltulas || is_forest_cleared)"
 
 #Specialty Macros
 "met_zelda": "event(MEET_ZELDA) || setting(skipZelda)"
@@ -358,6 +361,7 @@
 "can_kill_beamos": "soul_beamos && (has_explosives || can_use_mask_blast)"
 "can_kill_redead_gibdo": "soul_redead_gibdo && (can_use_sword_or_sticks || can_hammer || can_use_din)"
 "can_kill_redead_gibdo_no_c_button": "soul_redead_gibdo && can_use_sword"
+"can_kill_skulltulas": "can_use_sword_or_sticks || can_use_bow || can_use_hookshot || can_use_slingshot || can_use_din || can_hammer || has_explosives || can_use_mask_blast" # Assumes extreme close range
 "can_kill_skullwalltulas": "soul_skullwalltula && (can_use_slingshot || can_boomerang || can_use_bow || can_hookshot || can_hammer)"
 "can_kill_flare_dancer": "soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (can_hammer || can_hookshot || has_explosives) && (can_use_sword || can_hammer || can_use_bow)"
 "can_kill_dead_hand": "soul_enemy(SOUL_ENEMY_DEAD_HAND) && (can_use_sword || (can_use_sticks && trick(OOT_DEAD_HAND_STICKS)))"
@@ -431,7 +435,6 @@
 "rainbow_bridge_medallions": "has(MEDALLION_LIGHT) && has(MEDALLION_FOREST) && has(MEDALLION_FIRE) && has(MEDALLION_WATER) && has(MEDALLION_SHADOW) && has(MEDALLION_SPIRIT)"
 "rainbow_bridge": "setting(rainbowBridge, open) || (setting(rainbowBridge, vanilla) && rainbow_bridge_vanilla) || (setting(rainbowBridge, medallions) && rainbow_bridge_medallions) || (setting(rainbowBridge, custom) && special(BRIDGE))"
 
+# Region State
 "lake_water_control": "(setting(erBoss, none) && setting(regionState, dungeonBeaten) && event(BOSS_MORPHA)) || event(CLEAR_STATE_LAKE)"
-
-"break_icicle": "can_use_sword_or_sticks || has_explosives_or_hammer"
-"break_icicle_ice_cavern": "can_use_sword || has_explosives_or_hammer || (can_use_sticks && (trick(OOT_ICE_CAVERN_ICICLES_STICKS) || glitch_broken_stick))"
+"is_forest_cleared": "event(BOSS_PHANTOM_GANON)"

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -1,7 +1,7 @@
 #Generic Utility Macros
 "is_child": "age(child)"
 "is_adult": "age(adult)"
-"temp_flag_event(childEvent, adultEvent)": "(is_child && childEvent) || (is_adult && adultEvent)"
+"temp_flag_event(childEvent, adultEvent)": "(is_child && event(childEvent)) || (is_adult && event(adultEvent))"
 #"temp_flag_event_time_travel(childEvent, adultEvent)": "temp_flag_event(childEvent, adultEvent) || time_travel_at_will && (childEvent || adultEvent)" # This macro is only relevant for sitations where Link moves from one place he can time travel to a place he may not (e.g.s; 1 - because of ER, 2 - through a door to a boss room)
 "has_clock": "setting(clocksOot, none) || has(CLOCK)"
 "is_day": "(has_clock || setting(clocksOot, day)) && (oot_time(day) || can_play_sun || can_play_double_time)"

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -335,7 +335,7 @@
 "can_kill_tektites": "soul_tektite && (can_use_sword_or_sticks || can_hammer || can_use_slingshot || can_use_bow || has_explosives || can_use_din)"
 "can_kill_tektites_distance": "soul_tektite && (can_use_slingshot || can_use_bow)"
 "can_kill_leevers": "soul_leever && (has_sword || can_hammer || can_use_slingshot || can_use_bow || has_explosives || can_use_din)"
-"can_kill_peahats_ground": "soul_peahat && (can_use_sword_or_sticks || has_arrows || can_hammer || can_hookshot || can_use_slingshot) || (is_night && has_explosives))"
+"can_kill_peahats_ground": "soul_peahat && ((can_use_sword_or_sticks || has_arrows || can_hammer || can_hookshot || can_use_slingshot) || (is_night && has_explosives))"
 "can_kill_peahats_high": "soul_peahat && (can_use_slingshot || (is_night && has_explosives))"
 "can_kill_lizalfos_dinolfos": "soul_lizalfos_dinolfos && (can_use_sword_or_sticks || can_hammer || can_use_slingshot || can_use_bow)"
 "can_kill_larvae_eggs_low": "has_ranged_weapon || has_nuts"    #Can be used for clear rooms, but doesn't give enemy drops in OoTR.
@@ -349,7 +349,7 @@
 "can_kill_torch_slugs": "soul_enemy(SOUL_ENEMY_TORCH_SLUG) && (can_use_sword_or_sticks || can_hammer || cam_use_bow || can_use_mask_blast || has_explosives || has_sticks)"
 "can_kill_moblins": "soul_moblins && (can_use_sword_or_sticks || can_hammer || can_use_bow || can_hookshot)"
 "can_kill_poes": "soul_poe && (can_use_sword || can_hammer || can_use_slingshot || can_use_bow || can_hookshot)"
-"can_kill_poe_sisters": soul_poe && (can_use_sword || can_hammer || can_use_bow || can_hookshot)
+"can_kill_poe_sisters": "soul_poe && (can_use_sword || can_hammer || can_use_bow || can_hookshot)"
 "can_kill_poe_meg": "soul_poe && (can_use_bow || can_hookshot)"
 "can_kill_armos": "soul_armos && (((can_use_sword_kokiri || can_use_sword_goron) && has_nuts) || can_use_sword_razor || can_use_sword_master || can_use_sword_biggoron || can_use_sticks || can_hammer || can_use_mask_blast || has_explosives || (can_use_slingshot && (has_nuts || can_boomerang)))"
 #"can_kill_small_babas": "soul_deku_baba &&"       #No enemy drops currently in OoTR.

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -234,7 +234,7 @@
 "can_rescue_carpenter": "small_keys_hideout_all && (can_use_sword || ((can_boomerang || has_nuts) && can_use_sticks)) && soul_carpenters && soul_thief_fighter"
 "carpenters_rescued": "setting(gerudoFortress, open) || (event(CARPENTER_1) && (setting(gerudoFortress, single) || (event(CARPENTER_2) && event(CARPENTER_3) && event(CARPENTER_4))))"
 "get_past_skulltulas": "get_past_skulltulas_no_stone || can_use_mask_stone" #These both assume extreme close range
-"get_past_skulltulas_no_stone": "has_nuts || has_boomerang || can_kill_skulltulas || trick(GLITCH_OOT_SKULLTULA_ELEVATOR)"
+"get_past_skulltulas_no_stone": "has_nuts || can_boomerang || can_kill_skulltulas || trick(GLITCH_OOT_SKULLTULA_ELEVATOR)"
 "collect_gs_on_walls": "gs && (can_collect_distance || (has_ranged_weapon && climb_anywhere))" #TODO: Low/high macros like beehives; Din's, Blast mask, bomchus, bombs (if within throwing distance) and maybe even jump slashes if space permits (and damage?)
 "can_carry_keg": "can_lift_gold"
 "can_use_keg": "can_carry_keg && cond(setting(sharedPowderKeg), event(MM_BUY_KEG) || event(BUY_KEG), setting(powderKegOot) && event(BUY_KEG))"

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -343,7 +343,7 @@
 "can_kill_larvae_hatched": "soul_gohma_larvae && (can_use_sword_or_sticks || can_hammer || can_use_slingshot || can_use_bow || can_hookshot || has_explosives || can_use_din)"
 "can_kill_shaboms": "soul_shaboms && (can_use_sword || can_boomerang || has_nuts || has_explosives || can_use_din)"
 "can_kill_dark_link": "soul_enemy(SOUL_ENEMY_DARK_LINK) && (can_use_sword || can_hammer || (can_use_din && has_chateau))" #Double magic may be enough but due to Dark Link matching player health chateau as a mercy? Din's is weird here.
-"can_kill_biris_baris": "soul_biris_baris && (can_use_sword_or_sticks || can_boomerang || has_explosives || can_use_din))"
+"can_kill_biris_baris": "soul_biris_baris && (can_use_sword_or_sticks || can_boomerang || has_explosives || can_use_din)"
 "can_kill_tailpasarans": "soul_tailpasarans && (can_boomerang || can_use_sword_or_sticks || can_hammer)" #It should be noted that Ruto can kill them but most players wouldn't know this.
 "can_kill_jabu_parasites": "soul_enemy(SOUL_ENEMY_PARASITE) && can_boomerang" #Can have glitches or tricks for bombchu later on.
 "can_kill_torch_slugs": "soul_enemy(SOUL_ENEMY_TORCH_SLUG) && (can_use_sword_or_sticks || can_hammer || can_use_bow || can_use_mask_blast || has_explosives || has_sticks)"

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -361,7 +361,7 @@
 "can_kill_beamos": "soul_beamos && (has_explosives || can_use_mask_blast)"
 "can_kill_redead_gibdo": "soul_redead_gibdo && (can_use_sword_or_sticks || can_hammer || can_use_din)"
 "can_kill_redead_gibdo_no_c_button": "soul_redead_gibdo && can_use_sword"
-"can_kill_skulltulas": "can_use_sword_or_sticks || can_use_bow || can_use_hookshot || can_use_slingshot || can_use_din || can_hammer || has_explosives || can_use_mask_blast" # Assumes extreme close range
+"can_kill_skulltulas": "can_use_sword_or_sticks || can_use_bow || can_hookshot || can_use_slingshot || can_use_din || can_hammer || has_explosives || can_use_mask_blast" # Assumes extreme close range
 "can_kill_skullwalltulas": "soul_skullwalltula && (can_use_slingshot || can_boomerang || can_use_bow || can_hookshot || can_hammer)"
 "can_kill_flare_dancer": "soul_enemy(SOUL_ENEMY_FLARE_DANCER) && (can_hammer || can_hookshot || has_explosives) && (can_use_sword || can_hammer || can_use_bow)"
 "can_kill_dead_hand": "soul_enemy(SOUL_ENEMY_DEAD_HAND) && (can_use_sword || (can_use_sticks && trick(OOT_DEAD_HAND_STICKS)))"

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -346,7 +346,7 @@
 "can_kill_biris_baris": "soul_biris_baris && (can_use_sword_or_sticks || can_boomerang || has_explosives || can_use_din))"
 "can_kill_tailpasarans": "soul_tailpasarans && (can_boomerang || can_use_sword_or_sticks || can_hammer)" #It should be noted that Ruto can kill them but most players wouldn't know this.
 "can_kill_jabu_parasites": "soul_enemy(SOUL_ENEMY_PARASITE) && can_boomerang" #Can have glitches or tricks for bombchu later on.
-"can_kill_torch_slugs": "soul_enemy(SOUL_ENEMY_TORCH_SLUG) && (can_use_sword_or_sticks || can_hammer || cam_use_bow || can_use_mask_blast || has_explosives || has_sticks)"
+"can_kill_torch_slugs": "soul_enemy(SOUL_ENEMY_TORCH_SLUG) && (can_use_sword_or_sticks || can_hammer || can_use_bow || can_use_mask_blast || has_explosives || has_sticks)"
 "can_kill_moblins": "soul_moblins && (can_use_sword_or_sticks || can_hammer || can_use_bow || can_hookshot)"
 "can_kill_poes": "soul_poe && (can_use_sword || can_hammer || can_use_slingshot || can_use_bow || can_hookshot)"
 "can_kill_poe_sisters": "soul_poe && (can_use_sword || can_hammer || can_use_bow || can_hookshot)"

--- a/data/macros/macros_oot.yml
+++ b/data/macros/macros_oot.yml
@@ -249,7 +249,7 @@
 # Mido / Deku Tree
 "can_move_mido_reqs": "is_child && has_sword_kokiri && has_shield_deku"
 "can_move_mido": "can_move_mido_reqs && soul_npc(SOUL_NPC_MIDO)"
-"can_bypass_mido": "setting(dekuTree, open) || climb_anywhere || hookshot_anywhere || can_move_mido_reqs || is_adult && (get_past_skulltulas || is_forest_cleared)"
+"can_bypass_mido": "setting(dekuTree, open) || climb_anywhere || hookshot_anywhere || can_move_mido_reqs || (is_adult && (get_past_skulltulas || is_forest_cleared))"
 
 #Specialty Macros
 "met_zelda": "event(MEET_ZELDA) || setting(skipZelda)"

--- a/data/world/oot/dungeons/bottom_of_the_well.yml
+++ b/data/world/oot/dungeons/bottom_of_the_well.yml
@@ -19,7 +19,7 @@
 "Bottom of the Well Main":
   dungeon: BotW
   exits:
-    "Bottom of the Well Front Hallway": "get_past_skulltulas_no_stone || climb_anywhere" #climb anywhere works for either age
+    "Bottom of the Well Front Hallway": "true" # Use pot to kill skulltula
     "Bottom of the Well Wallmaster Main": "soul_wallmaster && has_lens"
     "Bottom of the Well Basement Platform": "has_lens || climb_anywhere || hookshot_anywhere"
   events:

--- a/data/world/oot/dungeons/bottom_of_the_well.yml
+++ b/data/world/oot/dungeons/bottom_of_the_well.yml
@@ -14,12 +14,12 @@
   dungeon: BotW
   exits:
     "Bottom of the Well": "is_child"
-    "Bottom of the Well Main": "has_nuts || can_use_sword || has_explosives_or_hammer || has_ranged_weapon || can_use_din"
+    "Bottom of the Well Main": "get_past_skulltulas_no_stone || climb_anywhere" #climb anywhere works for either age
 
 "Bottom of the Well Main":
   dungeon: BotW
   exits:
-    "Bottom of the Well Front Hallway": "has_nuts || can_use_sword || has_explosives_or_hammer || has_ranged_weapon || can_use_din"
+    "Bottom of the Well Front Hallway": "get_past_skulltulas_no_stone || climb_anywhere" #climb anywhere works for either age
     "Bottom of the Well Wallmaster Main": "soul_wallmaster && has_lens"
     "Bottom of the Well Basement Platform": "has_lens || climb_anywhere || hookshot_anywhere"
   events:

--- a/data/world/oot/dungeons/deku_tree.yml
+++ b/data/world/oot/dungeons/deku_tree.yml
@@ -9,7 +9,7 @@
   dungeon: DT
   exits:
     "Deku Tree Slingshot Room": "soul_deku_scrub && (has_shield_for_scrubs || can_hammer)"
-    "Deku Tree Basement": "has_fire || has_nuts || can_use_sword || has_explosives_or_hammer || has_ranged_weapon || can_use_sticks"
+    "Deku Tree Basement": "get_past_skulltulas"
   events:
     STICKS: "can_kill_baba_sticks"
     NUTS: "can_kill_baba_nuts"
@@ -26,7 +26,7 @@
     "Deku Tree Grass Compass Room 1": "can_cut_grass"
     "Deku Tree Grass Compass Room 2": "can_cut_grass"
     "Deku Tree Heart Main Room Lower": "true"
-    "Deku Tree Heart Main Room Upper": "has_fire || has_nuts || can_use_sword || has_explosives_or_hammer || has_ranged_weapon || can_use_sticks"
+    "Deku Tree Heart Main Room Upper": "get_past_skulltulas"
 
 "Deku Tree Slingshot Room":
   dungeon: DT

--- a/data/world/oot/dungeons/forest_temple.yml
+++ b/data/world/oot/dungeons/forest_temple.yml
@@ -3,7 +3,7 @@
   exits:
     "GLOBAL": "true"
     "Sacred Meadow Forest Platform": "true"
-    "Forest Temple Main": "can_damage || can_collect_distance || can_hammer"
+    "Forest Temple Main": "get_past_skulltulas"
   locations:
     "Forest Temple Tree Small Key": "true"
     "Forest Temple GS Entrance": "gs && (has_ranged_weapon || has_explosives || can_use_din)"

--- a/data/world/oot/dungeons/forest_temple.yml
+++ b/data/world/oot/dungeons/forest_temple.yml
@@ -21,7 +21,7 @@
 "Forest Temple Main":
   dungeon: Forest
   exits:
-    "Forest Temple": "true"
+    "Forest Temple": "get_past_skulltulas"
     "Forest Temple Mini-Boss": "true"
     "Forest Temple Garden West": "is_child || can_play_time"
     "Forest Temple Garden East": "can_hit_triggers_distance"

--- a/data/world/oot/dungeons/shadow_temple.yml
+++ b/data/world/oot/dungeons/shadow_temple.yml
@@ -45,11 +45,11 @@
     "Shadow Temple Main": "true"
     "Shadow Temple Boat": "(climb_anywhere && trick(OOT_SHADOW_BOAT_EARLY)) || event(SHADOW_SHORTCUT)"
   locations:
-    "Shadow Temple SR Scythe 1": "true"
-    "Shadow Temple SR Scythe 2": "can_hookshot || (is_adult && has_hover_boots) || climb_anywhere"
-    "Shadow Temple SR Scythe 3": "true"
-    "Shadow Temple SR Scythe 4": "true"
-    "Shadow Temple SR Scythe 5": "true"
+    "Shadow Temple SR Scythe 1": "true" # Floor, far side of scythe
+    "Shadow Temple SR Scythe 2": "can_hookshot || (is_adult && has_hover_boots) || climb_anywhere" # You can get this with nothing as adult with a good jump
+    "Shadow Temple SR Scythe 3": "true" # right alcove
+    "Shadow Temple SR Scythe 4": "true" # left alcove
+    "Shadow Temple SR Scythe 5": "true" # floor, near door
     "Shadow Temple Silver Rupees": "silver_rupees_shadow_scythe"
 
 "Shadow Temple Open":

--- a/data/world/oot/dungeons/thieves_hideout.yml
+++ b/data/world/oot/dungeons/thieves_hideout.yml
@@ -154,7 +154,7 @@
     "Gerudo Fortress Break Room Top": "can_hookshot || climb_anywhere"
   events:
     MAGIC: "evade_gerudo"
-    ARROWS: "is_adult && (has(GERUDO_CARD) || can_hookshot || has_mask_stone)"
+    ARROWS: "is_adult && (has(GERUDO_CARD) || can_hookshot || can_use_mask_stone)"
     SEEDS: "is_child && has(GERUDO_CARD)"
   locations:
     "Gerudo Fortress Pot Break Room 1": "true"

--- a/data/world/oot/dungeons_mq/deku_tree_mq.yml
+++ b/data/world/oot/dungeons_mq/deku_tree_mq.yml
@@ -218,7 +218,7 @@
   dungeon: DT
   exits:
     "MQ Deku Tree Water Room Front": "can_swim || (is_child && has_shield) || trick(OOT_DEKU_WATER_ROOM_SPIKE_NOTHING) || (is_adult && can_longshot) || hookshot_anywhere || climb_anywhere" #Can longshot the chest as both child and adult, but child cannot see the chest through the spike thing but can still longshot it. Adult can see it just fine. So for now, putting adult in as logic but can easily just make can_longshot if we want child to be able to cross without seeing the chest.
-    "MQ Deku Tree Water Room Door to Room After Water Room": "climb_anywhere || hookshot_anywhere || can_damage" #Need to kill the skultulla blocking the way.
+    "MQ Deku Tree Water Room Door to Room After Water Room": "true" #Both ages can climb around it: Child on the SoT block; Adult can just jump up the wall.
   events:
     MQ_DEKU_WATER_TORCHES: "has_fire"
   locations:

--- a/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
+++ b/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
@@ -15,15 +15,15 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Entrance": "has_explosives_or_hammer || (is_adult && has_bombflowers) || has_blue_fire_arrows_mudwall" #We need to see if you can go backwards without breaking it, like other mudwalls.
-    "Dodongo Cavern Main Room Inside Skull": "event(MQ_DC_OPEN_SKULL)"
-    "Dodongo Cavern Staircase Room Lower": "event(MQ_DC_STAIRCASE_SWITCH)"
-    "Dodongo Cavern Main Room Upper Skull Side": "event(MQ_DC_PILLAR_RAISE) || climb_anywhere || hookshot_anywhere" #You can use hook anywhere to get on top of the skull and again to get on the bridge without longshot.
+    "Dodongo Cavern Main Room Inside Skull": "event(DC_MQ_OPEN_SKULL)"
+    "Dodongo Cavern Staircase Room Lower": "event(DC_MQ_STAIRCASE_SWITCH)"
+    "Dodongo Cavern Main Room Upper Skull Side": "event(DC_MQ_PILLAR_RAISE) || climb_anywhere || hookshot_anywhere" #You can use hook anywhere to get on top of the skull and again to get on the bridge without longshot.
     "Dodongo Cavern Main Room Upper Entrance Side": "climb_anywhere || longshot_anywhere"
     "Dodongo Cavern Lower Tunnel": "has_explosives_or_hammer || (event(DC_MQ_SHORTCUT) && has_goron_bracelet) || has_blue_fire_arrows_mudwall"
     "Dodongo Cavern Bomb Bag Ledge": "is_adult || climb_anywhere || can_hookshot"
   events:
-    MQ_DC_PILLAR_RAISE: "has_bombflowers || can_hammer"
-    MQ_DC_OPEN_SKULL: "(hookshot_anywhere || climb_anywhere) && has_explosives"
+    DC_MQ_PILLAR_RAISE: "has_bombflowers || can_hammer"
+    DC_MQ_OPEN_SKULL: "(hookshot_anywhere || climb_anywhere) && has_explosives"
   locations:
     "MQ Dodongo Cavern Map Chest": "has_bombflowers || can_hammer || has_blue_fire_arrows_mudwall"
     "MQ Dodongo Cavern Lobby Scrub Front": "business_scrub(0x1c)"
@@ -40,8 +40,8 @@
     "Dodongo Cavern Vanilla Bomb Bag Room Upper": "event(DC_MQ_SHORTCUT) || hookshot_anywhere || (climb_anywhere && can_jump_slash)"
     "Dodongo Cavern Main Room Upper Entrance Side": "longshot_anywhere"
   events:
-    MQ_DC_OPEN_SKULL: "has_explosives"
-    MQ_DC_STAIRCASE_SWITCH: "true"
+    DC_MQ_OPEN_SKULL: "has_explosives"
+    DC_MQ_STAIRCASE_SWITCH: "true"
     DC_MQ_SHORTCUT: "has_explosives_or_hammer || can_use_din"
   locations:
     "MQ Dodongo Cavern Boulder Entrance Upper 1": "has_explosives_or_hammer"
@@ -52,11 +52,11 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Main Room Lower": "true"
-    "Dodongo Cavern Staircase Room Upper": "event(DC_MQ_STAIRCASE) || climb_anywhere || hookshot_anywhere"
+    "Dodongo Cavern Staircase Room Upper Walkways": "event(DC_MQ_STAIRCASE) || climb_anywhere || hookshot_anywhere"
     "Dodongo Cavern MQ Song of Time Block Room": "has_bombflowers || can_hammer || has_blue_fire_arrows_mudwall"
   events:
     STICKS: "soul_deku_baba && ((has_bombflowers || can_hammer || has_blue_fire_arrows_mudwall) && (has_weapon || can_boomerang))"
-    DC_MQ_STAIRCASE: "has_bombflowers || can_use_din"
+    DC_MQ_STAIRCASE: "has_bombflowers || can_use_din" #Permenant flag in MQ. Can lower it in one age and use in another. blast mask and bow work too
   locations:
     "MQ Dodongo Cavern SR Beamos": "true"
     "MQ Dodongo Cavern SR Crate": "true"
@@ -74,20 +74,28 @@
   locations:
     "MQ Dodongo Cavern GS Time Blocks": "gs && can_play_time && can_damage_skull"
 
-"Dodongo Cavern Staircase Room Upper":
+"Dodongo Cavern Staircase Room Upper Walkways":
   dungeon: DC
   exits:
-    "Dodongo Cavern Room After Upper Staircase": "silver_rupees_dc"
+    "Dodongo Cavern Staircase Room Upper Near Door": "get_past_skulltulas || climb_anywhere" # You can also jump past the skulltula (with nothing) as either age but it's tricky
     "Dodongo Cavern Staircase Room Lower": "true"
   locations:
     "MQ Dodongo Cavern SR Upper Corner Low": "true"
-    "MQ Dodongo Cavern SR Vines": "true"
     "MQ Dodongo Cavern SR Upper Corner High": "true"
     "MQ Dodongo Cavern Staircase Scrub": "business_scrub(0x1f)"
     "MQ Dodongo Cavern Staircase Room Upper Large Crate 1": "true"
     "MQ Dodongo Cavern Staircase Room Upper Large Crate 2": "true"
     "MQ Dodongo Cavern Staircase Room Upper Large Crate 3": "true"
     "MQ Dodongo Cavern Staircase Room Upper Large Crate 4": "true"
+    
+"Dodongo Cavern Staircase Room Upper Near Door":
+  dungeon: DC
+  exits:
+    "Dodongo Cavern Room After Upper Staircase": "silver_rupees_dc"
+    "Dodongo Cavern Staircase Room Upper Walkways": "get_past_skulltulas || climb_anywhere" # You can also jump past the skulltula (with nothing) as either age but it's somewhat tricky
+    "Dodongo Cavern Staircase Room Lower": "true"
+  locations:
+    "MQ Dodongo Cavern SR Vines": "true"
 
 "Dodongo Cavern Room After Upper Staircase":
   dungeon: DC
@@ -115,11 +123,11 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Main Room Upper Entrance Side": "true"
-    "Dodongo Cavern Room Before Upper Lizalfos": "(can_use_sticks && event(OPEN_MQ_DC_LARVAE_ROOM)) || has_fire"
+    "Dodongo Cavern Before Upper Lizalfos Room": "has_fire_or_sticks" # use fire or beat the 3-torch puzzle and carry flame. Fire/sticks kills skulltulas
     "Dodongo Cavern Vanilla Bomb Bag Room Upper": "can_hookshot || has_hover_boots || (is_adult && trick(OOT_DC_JUMP)) || climb_anywhere"
-    "Dodongo Cavern MQ Larvae Room": "event(OPEN_MQ_DC_LARVAE_ROOM)"
+    "Dodongo Cavern MQ Larvae Room": "has_fire_or_sticks || event(DC_MQ_SOLVE_3-TORCH_PUZZLE_TIME_TRAVEL)" # Either beat the 3-torch puzzle with the current age, or beat it with the other age then SoT-age-change.
   events:
-    OPEN_MQ_DC_LARVAE_ROOM: "can_use_sticks || has_fire"
+    DC_MQ_SOLVE_3-TORCH_PUZZLE_TIME_TRAVEL: "time_travel_at_will && has_fire_or_sticks" # Temp flag: not reset when using age change. Only age swap allows you to keep the puzzle solved for an age that can't solve it.
   locations:
     "MQ Dodongo Cavern Heart Vanilla Bomb Bag Room": "true"
     # Fails to load
@@ -141,11 +149,11 @@
 "Dodongo Cavern MQ Larvae Room":
   dungeon: DC
   exits:
-    "Dodongo Cavern Vanilla Bomb Bag Room Lower": "event(MQ_DC_CLEAR_LARVAE_ROOM)"
+    "Dodongo Cavern Vanilla Bomb Bag Room Lower": "event(DC_MQ_CLEAR_LARVAE_ROOM)"
   events:
-    MQ_DC_CLEAR_LARVAE_ROOM: "soul_enemy(SOUL_ENEMY_GOHMA_LARVA) && can_damage"
+    DC_MQ_CLEAR_LARVAE_ROOM: "soul_enemy(SOUL_ENEMY_GOHMA_LARVA) && can_damage"
   locations:
-    "MQ Dodongo Cavern Larvae Room Chest": "event(MQ_DC_CLEAR_LARVAE_ROOM)"
+    "MQ Dodongo Cavern Larvae Room Chest": "event(DC_MQ_CLEAR_LARVAE_ROOM)"
     "MQ Dodongo Cavern GS Larve Room": "gs && can_damage_skull"
     "MQ Dodongo Cavern Larve Room Large Crate 1": "true"
     "MQ Dodongo Cavern Larve Room Large Crate 2": "true"
@@ -153,19 +161,25 @@
     "MQ Dodongo Cavern Larve Room Large Crate 4": "true"
     "MQ Dodongo Cavern Larve Room Large Crate 5": "true"
     "MQ Dodongo Cavern Larve Room Large Crate 6": "true"
-
-"Dodongo Cavern Room Before Upper Lizalfos":
+    
+"Dodongo Cavern Before Upper Lizalfos Room":
   dungeon: DC
   exits:
-    "Dodongo Cavern Upper Lizalfos": "(event(MQ_DC_ROOM_BEFORE_UPPER_LIZALFOS_GOLD_TORCH) && can_use_sticks && has_goron_bracelet) || has_explosives_or_hammer || has_blue_fire_arrows_mudwall" #Needs macro for getting past enemies still in path
-    "Dodongo Cavern Vanilla Bomb Bag Room Lower": "has_fire"
-  events:
-    MQ_DC_ROOM_BEFORE_UPPER_LIZALFOS_GOLD_TORCH: "(can_use_sticks && event(OPEN_MQ_DC_LARVAE_ROOM)) || has_fire"
+    "Dodongo Cavern Before Upper Lizalfos Corridor End": "true" # If you got past skulltulas to get in here, you can get past them to get out
+    "Dogongo Cavern Vanilla Bomb Bag Room Lower": "true" # ditto + moves through invisible one way collision
   locations:
     "MQ Dodongo Cavern Pot Before Miniboss 1": "true"
     "MQ Dodongo Cavern Pot Before Miniboss 2": "true"
     # Fails to load
     "MQ Dodongo Cavern Grass Room Before Miniboss": "can_cut_grass"
+
+"Dodongo Cavern Before Upper Lizalfos Corridor End":
+  dungeon: DC
+  exits:
+    "Dodongo Cavern Upper Lizalfos": "event(DC_MQ_UPPER_LIZALFOS_MUDWALL_DESTROYED)" # Using event to permit one age to knock it down and the other to go through.
+    "Dodongo Cavern Before Upper Lizalfos Room": "get_past_skulltulas" # Possible to get knocked by them to the other side, but inconsistent
+  events:
+    "DC_MQ_UPPER_LIZALFOS_MUDWALL_DESTROYED": "(can_use_sticks && has_goron_bracelet) || has_explosives_or_hammer || has_blue_fire_arrows_mudwall"  # Permenant flag. Sticks alone is enough to carry fire from 3-torch puzzle
 
 "Dodongo Cavern Room After Upper Lizalfos":
   dungeon: DC
@@ -182,12 +196,12 @@
 "Dodongo Cavern Upper Lizalfos":
   dungeon: DC
   exits:
-    "Dodongo Cavern Room Before Upper Lizalfos": "event(MQ_DC_UPPER_LIZALFOS_CLEAR_FROM_UPPER) || event(MQ_DC_UPPER_LIZALFOS_CLEAR_FROM_LOWER)"
-    "Dodongo Cavern Room After Upper Lizalfos": "event(MQ_DC_UPPER_LIZALFOS_CLEAR_FROM_UPPER) || event(MQ_DC_UPPER_LIZALFOS_CLEAR_FROM_LOWER)"
+    "Dodongo Cavern Before Upper Lizalfos Corridor End": "event(DC_MQ_UPPER_LIZALFOS_CLEAR_FROM_UPPER) || event(DC_MQ_UPPER_LIZALFOS_CLEAR_FROM_LOWER)"
+    "Dodongo Cavern Room After Upper Lizalfos": "event(DC_MQ_UPPER_LIZALFOS_CLEAR_FROM_UPPER) || event(DC_MQ_UPPER_LIZALFOS_CLEAR_FROM_LOWER)"
     #"Dodongo Cavern Lower Lizalfos": "has_explosives_or_hammer || hookshot_anywhere || climb_anywhere"
   events:
-    MQ_DC_UPPER_LIZALFOS_CLEAR_FROM_UPPER: "soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
-    MQ_DC_LOWER_LIZALFOS_CLEAR_FROM_UPPER: "(time_travel_at_will && (has_explosives_or_hammer || hookshot_anywhere || climb_anywhere)) && soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
+    DC_MQ_UPPER_LIZALFOS_CLEAR_FROM_UPPER: "soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
+    DC_MQ_LOWER_LIZALFOS_CLEAR_FROM_UPPER: "(time_travel_at_will && (has_explosives_or_hammer || hookshot_anywhere || climb_anywhere)) && soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
   locations:
     "MQ Dodongo Cavern GS Upper Lizalfos": "gs && (has_explosives_or_hammer || (climb_anywhere && can_damage_skull) || longshot_anywhere)"
     "MQ Dodongo Cavern Pot Miniboss 1": "true"
@@ -211,11 +225,11 @@
 "Dodongo Cavern Lower Tunnel":
   dungeon: DC
   exits:
-    "Dodongo Cavern Corridor Before Lower Lizalfos": "event(MQ_DC_LOWER_TUNNEL_EYE_SWITCH)"
+    "Dodongo Cavern Corridor Before Lower Lizalfos": "event(DC_MQ_LOWER_TUNNEL_EYE_SWITCH)"
     "Dodongo Cavern Main Room Lower": "true"
     "Dodongo Cavern Lower Tunnel Side Room": "has_bombflowers || has_explosives_or_hammer || has_blue_fire_arrows_mudwall"
   events:
-    MQ_DC_LOWER_TUNNEL_EYE_SWITCH: "can_use_bow || ((has_bombflowers || can_use_din) && can_use_slingshot)"
+    DC_MQ_LOWER_TUNNEL_EYE_SWITCH: "can_use_bow || ((has_bombflowers || can_use_din) && can_use_slingshot)"
   locations:
     "MQ Dodongo Cavern Pot East Corridor 1": "true"
     "MQ Dodongo Cavern Pot East Corridor 2": "true"
@@ -240,12 +254,12 @@
 "Dodongo Cavern Lower Lizalfos":
   dungeon: DC
   exits:
-    "Dodongo Cavern Corridor Before Lower Lizalfos": "event(MQ_DC_LOWER_LIZALFOS_CLEAR_FROM_UPPER) || event(MQ_DC_LOWER_LIZALFOS_CLEAR_FROM_LOWER)"
-    "Dodongo Cavern Poe Room": "event(MQ_DC_LOWER_LIZALFOS_CLEAR_FROM_UPPER) || event(MQ_DC_LOWER_LIZALFOS_CLEAR_FROM_LOWER)"
+    "Dodongo Cavern Corridor Before Lower Lizalfos": "event(DC_MQ_LOWER_LIZALFOS_CLEAR_FROM_UPPER) || event(DC_MQ_LOWER_LIZALFOS_CLEAR_FROM_LOWER)"
+    "Dodongo Cavern Poe Room": "event(DC_MQ_LOWER_LIZALFOS_CLEAR_FROM_UPPER) || event(DC_MQ_LOWER_LIZALFOS_CLEAR_FROM_LOWER)"
     #"Dodongo Cavern Upper Lizalfos": "climb_anywhere || longshot_anywhere"
   events:
-    MQ_DC_LOWER_LIZALFOS_CLEAR_FROM_LOWER: "soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
-    MQ_DC_UPPER_LIZALFOS_CLEAR_FROM_LOWER: "((climb_anywhere || longshot_anywhere) && time_travel_at_will) && soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
+    DC_MQ_LOWER_LIZALFOS_CLEAR_FROM_LOWER: "soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
+    DC_MQ_UPPER_LIZALFOS_CLEAR_FROM_LOWER: "((climb_anywhere || longshot_anywhere) && time_travel_at_will) && soul_lizalfos_dinolfos && (can_use_sticks || has_weapon || can_use_slingshot)"
   locations:
     "MQ Dodongo Cavern Heart Lizalfos Room": "true"
     "MQ Dodongo Cavern GS Upper Lizalfos": "gs && (longshot_anywhere || (climb_anywhere && can_damage_skull))" #In Upper section, putting it here too because of the lizalfos event won't trigger when starting in opposite section.
@@ -258,10 +272,10 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Lower Lizalfos": "true"
-    "Dodongo Cavern Bomb Bag Ledge": "event(MQ_DC_POE_ROOM_BOMB_SWITCHES)"
-    "Dodongo Cavern MQ Poe Room Side Room": "event(MQ_DC_POE_ROOM_BOMB_SWITCHES)"
+    "Dodongo Cavern Bomb Bag Ledge": "event(DC_MQ_POE_ROOM_BOMB_SWITCHES)"
+    "Dodongo Cavern MQ Poe Room Side Room": "event(DC_MQ_POE_ROOM_BOMB_SWITCHES)"
   events:
-    MQ_DC_POE_ROOM_BOMB_SWITCHES: "can_use_bow || has_bombflowers || can_use_din"
+    DC_MQ_POE_ROOM_BOMB_SWITCHES: "can_use_bow || has_bombflowers || can_use_din"
   locations:
     "MQ Dodongo Cavern Pot Green Room 1": "true"
     "MQ Dodongo Cavern Pot Green Room 2": "true"
@@ -296,14 +310,14 @@
 "Dodongo Cavern Main Room Inside Skull":
   dungeon: DC
   exits:
-    "Dodongo Cavern Main Room Lower": "event(MQ_DC_OPEN_SKULL)"
+    "Dodongo Cavern Main Room Lower": "event(DC_MQ_OPEN_SKULL)"
     "Dodongo Cavern Pre-Boss Lobby": "true"
 
 "Dodongo Cavern Pre-Boss Lobby":
   dungeon: DC
   exits:
     "Dodongo Cavern Main Room Inside Skull": "true"
-    "Dodongo Cavern Boss": "event(MQ_DC_BOSS_SWITCH)"
+    "Dodongo Cavern Boss": "event(DC_MQ_BOSS_SWITCH)"
     "Dodongo Cavern Boss Loop Start": "true"
     "Dodongo Cavern Boss Loop Ending Ledge": "is_adult || climb_anywhere || hookshot_anywhere"
   locations:
@@ -314,9 +328,9 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Pre-Boss Lobby": "true"
-    "Dodongo Cavern Boss Loop After Fire Wall": "is_adult || climb_anywhere || hookshot_anywhere || event(MQ_DC_BOSS_LOOP_FIRE_WALL_CRYSTAL_BEFORE_FIRE)"
+    "Dodongo Cavern Boss Loop After Fire Wall": "is_adult || climb_anywhere || hookshot_anywhere || event(DC_MQ_BOSS_LOOP_FIRE_WALL_CRYSTAL_BEFORE_FIRE)"
   events:
-    MQ_DC_BOSS_LOOP_FIRE_WALL_CRYSTAL_BEFORE_FIRE: "has_bombs || has_bombchu"
+    DC_MQ_BOSS_LOOP_FIRE_WALL_CRYSTAL_BEFORE_FIRE: "has_bombs || has_bombchu"
   locations:
     "MQ Dodongo Cavern Pot Before Boss Loop 1": "true"
     "MQ Dodongo Cavern Pot Before Boss Loop 2": "true"
@@ -325,10 +339,10 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Boss Loop Side Room": "true"
-    "Dodongo Cavern Boss Loop Start": "event(MQ_DC_BOSS_LOOP_FIRE_WALL_CRYSTAL_AFTER_FIRE) || climb_anywhere || hookshot_anywhere"
+    "Dodongo Cavern Boss Loop Start": "event(DC_MQ_BOSS_LOOP_FIRE_WALL_CRYSTAL_AFTER_FIRE) || climb_anywhere || hookshot_anywhere"
     "Dodongo Cavern Boss Loop After Armos Wall": "climb_anywhere || hookshot_anywhere || has_fire || has_explosives"
   events:
-    MQ_DC_BOSS_LOOP_FIRE_WALL_CRYSTAL_AFTER_FIRE: "has_weapon || has_bombs || can_use_mask_blast || has_bombchu || can_use_bow || can_use_slingshot || can_hookshot || can_use_sticks || can_hammer || can_boomerang" #Many ways to hit crystal switch
+    DC_MQ_BOSS_LOOP_FIRE_WALL_CRYSTAL_AFTER_FIRE: "has_weapon || has_bombs || can_use_mask_blast || has_bombchu || can_use_bow || can_use_slingshot || can_hookshot || can_use_sticks || can_hammer || can_boomerang" #Many ways to hit crystal switch
   locations:
     "MQ Dodongo Cavern GS Near Boss": "gs && can_damage_skull"
     "MQ Dodongo Cavern Grass Boss Loop": "can_cut_grass"
@@ -358,4 +372,4 @@
     "Dodongo Cavern Pre-Boss Lobby": "true"
     "Dodongo Cavern Boss Loop After Armos Wall": "true"
   events:
-    MQ_DC_BOSS_SWITCH: "true"
+    DC_MQ_BOSS_SWITCH: "true"

--- a/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
+++ b/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
@@ -100,7 +100,7 @@
 "Dodongo Cavern Room After Upper Staircase":
   dungeon: DC
   exits:
-    "Dodongo Cavern Staircase Room Upper": "true"
+    "Dodongo Cavern Staircase Room Upper Near Door": "true"
     "Dodongo Cavern Main Room Upper Entrance Side": "event(DC_MQ_DEFEAT_DONDONGOS_AFTER_STAIRCASE)"
   events:
     DC_MQ_DEFEAT_DONDONGOS_AFTER_STAIRCASE: "soul_dodongo && can_damage" #Placeholder macro for defeating Dodongos
@@ -166,7 +166,7 @@
   dungeon: DC
   exits:
     "Dodongo Cavern Before Upper Lizalfos Corridor End": "true" # If you got past skulltulas to get in here, you can get past them to get out
-    "Dogongo Cavern Vanilla Bomb Bag Room Lower": "true" # ditto + moves through invisible one way collision
+    "Dodongo Cavern Vanilla Bomb Bag Room Lower": "true" # ditto + moves through invisible one way collision
   locations:
     "MQ Dodongo Cavern Pot Before Miniboss 1": "true"
     "MQ Dodongo Cavern Pot Before Miniboss 2": "true"

--- a/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
+++ b/data/world/oot/dungeons_mq/dodongo_cavern_mq.yml
@@ -125,9 +125,9 @@
     "Dodongo Cavern Main Room Upper Entrance Side": "true"
     "Dodongo Cavern Before Upper Lizalfos Room": "has_fire_or_sticks" # use fire or beat the 3-torch puzzle and carry flame. Fire/sticks kills skulltulas
     "Dodongo Cavern Vanilla Bomb Bag Room Upper": "can_hookshot || has_hover_boots || (is_adult && trick(OOT_DC_JUMP)) || climb_anywhere"
-    "Dodongo Cavern MQ Larvae Room": "has_fire_or_sticks || event(DC_MQ_SOLVE_3-TORCH_PUZZLE_TIME_TRAVEL)" # Either beat the 3-torch puzzle with the current age, or beat it with the other age then SoT-age-change.
+    "Dodongo Cavern MQ Larvae Room": "has_fire_or_sticks || event(DC_MQ_SOLVE_3_TORCH_PUZZLE_TIME_TRAVEL)" # Either beat the 3-torch puzzle with the current age, or beat it with the other age then SoT-age-change.
   events:
-    DC_MQ_SOLVE_3-TORCH_PUZZLE_TIME_TRAVEL: "time_travel_at_will && has_fire_or_sticks" # Temp flag: not reset when using age change. Only age swap allows you to keep the puzzle solved for an age that can't solve it.
+    DC_MQ_SOLVE_3_TORCH_PUZZLE_TIME_TRAVEL: "time_travel_at_will && has_fire_or_sticks" # Temp flag: not reset when using age change. Only age swap allows you to keep the puzzle solved for an age that can't solve it.
   locations:
     "MQ Dodongo Cavern Heart Vanilla Bomb Bag Room": "true"
     # Fails to load

--- a/data/world/oot/dungeons_mq/forest_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/forest_temple_mq.yml
@@ -20,8 +20,8 @@
   exits: #Maybe make the upper branches where the event takes place its own region?
     "Forest Temple": "true"
     "Forest Temple Initial Hallway Front": "true"
-  events: #longshot_anywhere is for action shuffle and not being able to climb; redundant currently with can_hookshot
-    FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH: "can_longshot || climb_anywhere || (has_nuts || can_hit_triggers_distance || can_hookshot || has_hover_boots || can_use_din || has_bomb_bag || can_use_mask_stone || (has_weapon && (has(MAGIC_UPGRADE) || has(SHARED_MAGIC_UPGRADE))))" #Many ways to deal with the Skulltula in the way.
+  events: #longshot is for action shuffle and not being able to climb; redundant currently with can_hookshot within the has_ranged_weapon macro
+    FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH: "can_longshot || climb_anywhere || has_nuts || can_use_sword_or_sticks || has_ranged_weapon || can_use_din || has_bombs || can_use_mask_blast || can_use_mask_stone || has_hover_boots || trick(OOT_FOREST_MQ_STAND_IN_FRONT_OF_LOBBY_SKULLTULA) && (has_bombchu || can_hammer || trick(GLITCH_OOT_SKULLTULA_ELEVATOR))" #Many ways to deal with the Skulltula in the way.
   locations:
     "MQ Forest Temple First Room Chest": "event(FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH)"
 
@@ -29,18 +29,18 @@
   dungeon: Forest
   exits:
     "Forest Temple Entrance Room": "true"
-    "Forest Temple Initial Hallway Navigation": "get_past_skultullas"
+    "Forest Temple Initial Hallway Navigation": "get_past_skulltulas"
 
-"Forest Temple Initial Hallway Navigation": #Even more ways to get past the skultulas. Region exists for enemy drops rando, and for ease of placing the door regions for door rando.
+"Forest Temple Initial Hallway Navigation": #Region exists for enemy drops rando, and for ease of placing the door regions for door rando. Middle Skultula sorta needs roll with adult+stone mask.
   dungeon: Forest
   exits:
-    "Forest Temple Initial Hallway Front": "get_past_skultullas"
-    "Forest Temple Initial Hallway Back": "get_past_skultullas"
+    "Forest Temple Initial Hallway Front": "get_past_skulltulas" 
+    "Forest Temple Initial Hallway Back": "get_past_skulltulas"
 
 "Forest Temple Initial Hallway Back":
   dungeon: Forest
   exits:
-    "Forest Temple Initial Hallway Navigation": "get_past_skultullas"
+    "Forest Temple Initial Hallway Navigation": "get_past_skulltulas"
     "Forest Temple Main Lobby": "small_keys_forest(1)"
   locations:
     "MQ Forest Temple GS Entryway": "gs && (can_collect_distance || ((has_ranged_weapon || has_explosives) && climb_anywhere))" #Blast mask too? Need to have separate macros for close vs far-range explosives...
@@ -201,7 +201,8 @@
     "Forest Temple Climbing Block Puzzle Room Crystal Switch Alcove": "true"
     "Forest Temple West Garden Ledge Above Well": "has_hover_boots || hookshot_anywhere || climb_anywhere"
   events:
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire_arrows"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && has_fire_arrows"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && has_fire_arrows"
 
 "Forest Temple West Garden Pillar With Items":
   dungeon: Forest
@@ -228,7 +229,8 @@
     "Forest Temple West Garden Ground Area": "true"
     "Forest Temple West Garden Upper Ledge Hallway": "hookshot_anywhere"
   events:
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire_arrows"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && has_fire_arrows"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && has_fire_arrows"
   locations:
     "MQ Forest Temple GS West Garden": "gs && can_damage_skull"
 
@@ -240,34 +242,38 @@
     "Forest Temple Main Lobby": "true"
     "Forest Temple Gardens Well": "(has_tunic_zora && has_iron_boots) || event(FOREST_MQ_DRAIN_WELL)"
     "Forest Temple West Garden Ledge Above Well": "true"
-    "Forest Temple West Garden Webbed Alcove": "event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY)" #Maybe another way to destroy web with glitches?
+    "Forest Temple West Garden Webbed Alcove": "temp_flag_event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD, FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT) && (can_kill_skulltulas || is_child && can_use_mask_stone)" # 5% of the time, adult link with stone mask gets knocked down. 95% of the time he gets knocked INTO the alcove.
     "Forest Temple East Garden Ground Area": "(has_tunic_zora && can_dive_big) || event(FOREST_MQ_DRAIN_WELL)" #Not part of Well region because diving with scale can't get checks.
   events:
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire_arrows"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && has_fire_arrows" #Maybe another way to destroy web with glitches?
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && has_fire_arrows"
 
 "Forest Temple West Garden Webbed Alcove":
   dungeon: Forest
   exits:
-    "Forest Temple West Garden Ground Area": "event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY)"
-    "Forest Temple Linking Room Between Gardens Behind Web": "true"
+    "Forest Temple West Garden Ground Area": "temp_flag_event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD, FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT) || trick(OOT_PASS_COLLISION)"
+    "Forest Temple Linking Room Between Gardens": "true" # Failsafe: door rando might actually put you in "Linking Room Between Gardens Behind Web"
   events:
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && has_fire" # These events will be a problem in door rando
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && has_fire" # since we have one event, one temp flag and two webs in two different rooms.
 
 "Forest Temple Linking Room Between Gardens Behind Web":
   dungeon: Forest
   exits:
     "Forest Temple West Garden Webbed Alcove": "true"
-    "Forest Temple Linking Room Between Gardens": "event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY)"
+    "Forest Temple Linking Room Between Gardens": "true" # Walk through INvisible one-way collision
   events:
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "has_fire"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && has_fire"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && has_fire"
 
 "Forest Temple Linking Room Between Gardens":
   dungeon: Forest
   exits:
     "Forest Temple East Garden Top Balcony With Door": "true"
-    "Forest Temple Linking Room Between Gardens Behind Web": "event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY)"
+    "Forest Temple Linking Room Between Gardens Behind Web": "temp_flag_event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD, FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT)"
   events:
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY: "can_use_din || has_arrows"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && can_use_din || has_arrows || has_sticks"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && can_use_din || has_arrows || has_sticks"
 
 "Forest Temple Gardens Well":
   dungeon: Forest
@@ -444,7 +450,7 @@
   dungeon: Forest
   exits:
     "Forest Temple Main Lobby": "event(FOREST_MQ_MEG_CLEAR)"
-    "Forest Temple Antichamber Room Southwest Alcove": "get_past_skultullas_no_stone" #You can roll into and out of the room with nothing. Trick or base?
+    "Forest Temple Antichamber Room Southwest Alcove": "true" #You can walk into and out of the room with nothing; you will get hit by the skulltula as you enter/leave though, unless you're child.
     "Forest Temple Antichamber Room East Alcove": "event(FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_CRYSTAL_SWITCH)"
     "Forest Temple Antichamber Room Northwest Alcove": "true"
     "Forest Temple Antichamber Room South Alcove": "event(FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_FLOOR_SWITCH)"

--- a/data/world/oot/dungeons_mq/forest_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/forest_temple_mq.yml
@@ -21,7 +21,7 @@
     "Forest Temple": "true"
     "Forest Temple Initial Hallway Front": "true"
   events: #longshot is for action shuffle and not being able to climb; redundant currently with can_hookshot within the has_ranged_weapon macro
-    FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH: "can_longshot || climb_anywhere || has_nuts || can_use_sword_or_sticks || has_ranged_weapon || can_use_din || has_bombs || can_use_mask_blast || can_use_mask_stone || has_hover_boots || trick(OOT_FOREST_MQ_STAND_IN_FRONT_OF_LOBBY_SKULLTULA) && (has_bombchu || can_hammer || trick(GLITCH_OOT_SKULLTULA_ELEVATOR))" #Many ways to deal with the Skulltula in the way.
+    FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH: "can_longshot || climb_anywhere || has_nuts || can_use_sword_or_sticks || has_ranged_weapon || can_use_din || has_bombs || can_use_mask_blast || can_use_mask_stone || has_hover_boots || (trick(OOT_FOREST_MQ_STAND_IN_FRONT_OF_LOBBY_SKULLTULA) && (has_bombchu || can_hammer || trick(GLITCH_OOT_SKULLTULA_ELEVATOR)))" #Many ways to deal with the Skulltula in the way.
   locations:
     "MQ Forest Temple First Room Chest": "event(FOREST_MQ_ENTRANCE_ROOM_CHEST_SWITCH)"
 
@@ -242,7 +242,7 @@
     "Forest Temple Main Lobby": "true"
     "Forest Temple Gardens Well": "(has_tunic_zora && has_iron_boots) || event(FOREST_MQ_DRAIN_WELL)"
     "Forest Temple West Garden Ledge Above Well": "true"
-    "Forest Temple West Garden Webbed Alcove": "temp_flag_event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD, FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT) && (can_kill_skulltulas || is_child && can_use_mask_stone)" # 5% of the time, adult link with stone mask gets knocked down. 95% of the time he gets knocked INTO the alcove.
+    "Forest Temple West Garden Webbed Alcove": "temp_flag_event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD, FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT) && (can_kill_skulltulas || (is_child && can_use_mask_stone))" # 5% of the time, adult link with stone mask gets knocked down. 95% of the time he gets knocked INTO the alcove.
     "Forest Temple East Garden Ground Area": "(has_tunic_zora && can_dive_big) || event(FOREST_MQ_DRAIN_WELL)" #Not part of Well region because diving with scale can't get checks.
   events:
     FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && has_fire_arrows" #Maybe another way to destroy web with glitches?
@@ -272,8 +272,8 @@
     "Forest Temple East Garden Top Balcony With Door": "true"
     "Forest Temple Linking Room Between Gardens Behind Web": "temp_flag_event(FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD, FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT)"
   events:
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && can_use_din || has_arrows || has_sticks"
-    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && can_use_din || has_arrows || has_sticks"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_CHILD: "is_child && (can_use_din || has_arrows || has_sticks)"
+    FOREST_MQ_WEST_GARDEN_HIGH_WEB_DESTROY_ADULT: "is_adult && (can_use_din || has_arrows || has_sticks)"
 
 "Forest Temple Gardens Well":
   dungeon: Forest

--- a/data/world/oot/dungeons_mq/forest_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/forest_temple_mq.yml
@@ -450,7 +450,7 @@
   dungeon: Forest
   exits:
     "Forest Temple Main Lobby": "event(FOREST_MQ_MEG_CLEAR)"
-    "Forest Temple Antichamber Room Southwest Alcove": "get_past_skultullas_no_stone" #You can walk into and out of the room with nothing; you will get hit by the skulltula as you enter/leave though, unless you're child.
+    "Forest Temple Antichamber Room Southwest Alcove": "get_past_skulltulas_no_stone" #You can walk into and out of the room with nothing; you will get hit by the skulltula as you enter/leave though, unless you're child.
     "Forest Temple Antichamber Room East Alcove": "event(FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_CRYSTAL_SWITCH)"
     "Forest Temple Antichamber Room Northwest Alcove": "true"
     "Forest Temple Antichamber Room South Alcove": "event(FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_FLOOR_SWITCH)"

--- a/data/world/oot/dungeons_mq/forest_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/forest_temple_mq.yml
@@ -31,7 +31,7 @@
     "Forest Temple Entrance Room": "true"
     "Forest Temple Initial Hallway Navigation": "get_past_skulltulas"
 
-"Forest Temple Initial Hallway Navigation": #Region exists for enemy drops rando, and for ease of placing the door regions for door rando. Middle Skultula sorta needs roll with adult+stone mask.
+"Forest Temple Initial Hallway Navigation": #Region exists for enemy drops rando, and for ease of placing the door regions for door rando. Middle Skulltula sorta needs roll with adult+stone mask.
   dungeon: Forest
   exits:
     "Forest Temple Initial Hallway Front": "get_past_skulltulas" 
@@ -450,7 +450,7 @@
   dungeon: Forest
   exits:
     "Forest Temple Main Lobby": "event(FOREST_MQ_MEG_CLEAR)"
-    "Forest Temple Antichamber Room Southwest Alcove": "true" #You can walk into and out of the room with nothing; you will get hit by the skulltula as you enter/leave though, unless you're child.
+    "Forest Temple Antichamber Room Southwest Alcove": "get_past_skultullas_no_stone" #You can walk into and out of the room with nothing; you will get hit by the skulltula as you enter/leave though, unless you're child.
     "Forest Temple Antichamber Room East Alcove": "event(FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_CRYSTAL_SWITCH)"
     "Forest Temple Antichamber Room Northwest Alcove": "true"
     "Forest Temple Antichamber Room South Alcove": "event(FOREST_MQ_ANTICHAMBER_EAST_ALCOVE_FLOOR_SWITCH)"

--- a/data/world/oot/dungeons_mq/shadow_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/shadow_temple_mq.yml
@@ -140,22 +140,22 @@
 "Shadow Temple Scythe Room":
   dungeon: Shadow
   exits:
-    "Shadow Temple First Beamos Fork Room Lens Alcove to Scythe and Shortcut Room": "event(SHADOW_MQ_SCYTHE_ROOM_SKULTULLAS_CLEAR)" #Don't need SR itself to exit, only the skultullas. See below comment.
-    "Shadow Temple Enclosed Shortcut Area": "has_lens && get_past_skultullas"
+    "Shadow Temple First Beamos Fork Room Lens Alcove to Scythe and Shortcut Room": "event(SHADOW_MQ_SCYTHE_ROOM_SKULLTULAS_CLEAR)" #Don't need SR itself to exit, only the skulltulas.
+    "Shadow Temple Enclosed Shortcut Area": "has_lens && get_past_skulltulas" 
   events:
-    SHADOW_MQ_SCYTHE_ROOM_SKULTULLAS_CLEAR: "soul_skulltula && (can_use_din || (silver_rupees_shadow_scythe && (can_damage || has_ranged_weapon_adult || can_use_slingshot || can_hammer)))"
-  locations:
-    "MQ Shadow Temple SR Scythe 1": "true"
-    "MQ Shadow Temple SR Scythe 2": "can_hookshot || (is_adult && has_hover_boots) || climb_anywhere"
-    "MQ Shadow Temple SR Scythe 3": "true"
-    "MQ Shadow Temple SR Scythe 4": "true"
-    "MQ Shadow Temple SR Scythe 5": "true"
-    "MQ Shadow Temple Map Chest": "silver_rupees_shadow_scythe"
+    SHADOW_MQ_SCYTHE_ROOM_SKULLTULAS_CLEAR: "soul_skulltula && (can_use_din || (silver_rupees_shadow_scythe && (can_damage || has_ranged_weapon_adult || can_use_slingshot || can_hammer)))" # too restrictive? you can jumpslash through the gate, even with child kokiri sword. Fully charged child kokiri sword spin slash works too. MQ already expects you to know about this 'exploit' later in the dungeon, when you hit a switch through a gate.
+  locations: # Adult Link can roll under these skulltulas with stone mask
+    "MQ Shadow Temple SR Scythe 1": "get_past_skulltulas" #left alcove. You can get around the skulltula by getting repeatedly hit (child or adult).
+    "MQ Shadow Temple SR Scythe 2": "can_hookshot || (is_adult && has_hover_boots) || climb_anywhere" # You can get this with nothing as adult with a good jump
+    "MQ Shadow Temple SR Scythe 3": "true" # floor, far
+    "MQ Shadow Temple SR Scythe 4": "true" # floor, near
+    "MQ Shadow Temple SR Scythe 5": "get_past_skulltulas" # back right alcove.
+    "MQ Shadow Temple Map Chest": "silver_rupees_shadow_scythe" # TODO: solve the issue where child and adult can collect subsets of silver rupees that logic thinks combine into a complete simultaenous collection.
 
 "Shadow Temple Enclosed Shortcut Area":
   dungeon: Shadow
   exits:
-    "Shadow Temple Scythe Room": "get_past_skultullas"
+    "Shadow Temple Scythe Room": "get_past_skulltulas"
     "Shadow Temple Area Before Boat Ride": "event(SHADOW_MQ_SHORTCUT_BLOCK_PUSHED)" #TODO: Add the glitch to jump through wall and skip this.
     "Shadow Temple Area Above Shortcut Enclosure": "climb_anywhere && trick(OOT_SHADOW_BOAT_EARLY)"
   locations:
@@ -171,13 +171,13 @@
   dungeon: Shadow
   exits:
     "Shadow Temple First Beamos Fork Room Solid Wall Alcove to Guillotine Hallway": "small_keys_shadow(2)"
-    "Shadow Temple Lower Guillotine Hallway Before Upper Huge Pit": "true" #Can avoid all beamos and skultullas.
+    "Shadow Temple Lower Guillotine Hallway Before Upper Huge Pit": "true" #Can avoid all beamos and skulltulas.
 
 "Shadow Temple Lower Guillotine Hallway Before Upper Huge Pit":
   dungeon: Shadow
   exits:
     "Shadow Temple Upper Guillotine Hallway Before Upper Huge Pit": "can_hookshot || climb_anywhere"
-    "Shadow Temple Upper Huge Pit Guillotine Section Before Drop": "true" #Can avoid all beamos and skultullas.
+    "Shadow Temple Upper Huge Pit Guillotine Section Before Drop": "true" #Can avoid all beamos and skulltulas.
     "Shadow Temple Lower Huge Pit Ledge Before Invisible Spike Floors": "climb_anywhere"
 
 "Shadow Temple Upper Huge Pit Guillotine Section Before Drop":
@@ -310,12 +310,12 @@
   dungeon: Shadow
   exits:
     "Shadow Temple Invisible Spike Floors Room Upper Ledge Before Door": "small_keys_shadow(4)"
-    "Shadow Temple Wind Tunnel After Pit Before Drop": "get_past_skultullas && (has_hover_boots || hookshot_anywhere || climb_anywhere)" #Need to get past Skultulla and the pit
+    "Shadow Temple Wind Tunnel After Pit Before Drop": "(can_kill_skulltulas || has_nuts || has_boomerang || can_use_mask_stone || (trick(GLITCH_OOT_SKULLTULA_ELEVATOR) && has_iron_boots)) && (has_hover_boots || can_hookshot || climb_anywhere)" #Need to get past Skulltula and the pit. Skulltula Elevator needs to be combined with some way to stop being pushed too far away from the Skulltula such that it resets.
 
 "Shadow Temple Wind Tunnel After Pit Before Drop":
   dungeon: Shadow
   exits:
-    "Shadow Temple Wind Tunnel First Part": "true" #Can use the wind to jump across and the other wind to get past the skultulla.
+    "Shadow Temple Wind Tunnel First Part": "true" #Can use the wind to jump across and the other wind to get past the skulltula.
     "Shadow Temple Wind Tunnel After Drop": "true"
 
 "Shadow Temple Wind Tunnel After Drop":
@@ -408,7 +408,7 @@
   events:
     SHADOW_MQ_AFTER_BOAT_BRIDGE_FALL: "can_use_bow"
   locations:
-    "MQ Shadow Temple GS After Boat": "gs && (can_hookshot || can_use_bow || can_use_slingshot || can_use_din || has_explosives || (can_boomerang && event(SHADOW_MQ_AFTER_BOAT_BRIDGE_FALL)))" #Can fall to skultulla after killing it. The angle is a little tricky though, but totally doable. Boomerang, though, is possible without the bridge but should be a trick. TODO: trick: boomerang no bridge
+    "MQ Shadow Temple GS After Boat": "gs && (can_hookshot || can_use_bow || can_use_slingshot || can_use_din || has_explosives || (can_boomerang && event(SHADOW_MQ_AFTER_BOAT_BRIDGE_FALL)))" #Can fall to skulltula after killing it. The angle is a little tricky though, but totally doable. Boomerang, though, is possible without the bridge but should be a trick. TODO: trick: boomerang no bridge
     "MQ Shadow Temple Pot After Boat Before Bridge 1": "true"
     "MQ Shadow Temple Pot After Boat Before Bridge 2": "true"
 

--- a/data/world/oot/dungeons_mq/shadow_temple_mq.yml
+++ b/data/world/oot/dungeons_mq/shadow_temple_mq.yml
@@ -310,7 +310,7 @@
   dungeon: Shadow
   exits:
     "Shadow Temple Invisible Spike Floors Room Upper Ledge Before Door": "small_keys_shadow(4)"
-    "Shadow Temple Wind Tunnel After Pit Before Drop": "(can_kill_skulltulas || has_nuts || has_boomerang || can_use_mask_stone || (trick(GLITCH_OOT_SKULLTULA_ELEVATOR) && has_iron_boots)) && (has_hover_boots || can_hookshot || climb_anywhere)" #Need to get past Skulltula and the pit. Skulltula Elevator needs to be combined with some way to stop being pushed too far away from the Skulltula such that it resets.
+    "Shadow Temple Wind Tunnel After Pit Before Drop": "(can_kill_skulltulas || has_nuts || can_boomerang || can_use_mask_stone || (trick(GLITCH_OOT_SKULLTULA_ELEVATOR) && has_iron_boots)) && (has_hover_boots || can_hookshot || climb_anywhere)" #Need to get past Skulltula and the pit. Skulltula Elevator needs to be combined with some way to stop being pushed too far away from the Skulltula such that it resets.
 
 "Shadow Temple Wind Tunnel After Pit Before Drop":
   dungeon: Shadow

--- a/packages/core/src/settings/tricks.ts
+++ b/packages/core/src/settings/tricks.ts
@@ -349,6 +349,12 @@ export const TRICKS: Tricks = {
     name: "Backflip/Sidehop Over Gap to Reach BotW MQ's Main Room's Center",
     tooltip: "Makes the center of the main room reachable without Zelda's Lullaby or Hover Boots by entering the left cage and backflipping/sidehopping over the invisible gap",
   },
+  OOT_FOREST_MQ_STAND_IN_FRONT_OF_LOBBY_SKULLTULA: {
+    game: 'oot',
+    name: "Stand in front of Forest MQ Lobby Skulltula",
+    tooltip: "The Skulltula guarding a high tree branch in Forest MQ's first room has a small patch of ground in front of it where Link can stand freely. Using this ground, Link can use hammer or bombchus to kill the Skulltula, or bypass it by combining this trick with the 'Skulltula Elevator' glitch",
+    linkVideo: "https://www.youtube.com/watch?v=zcr465LTwEU",
+  },
   OOT_FOREST_MQ_CLIMBING_BLOCK_ROOM_TWIST_SWITCH_EARLY: {
     game: 'oot',
     name: "Hit/Reach the Forest MQ Twisting Switch While It Is Blocked",
@@ -833,6 +839,13 @@ export const TRICKS: Tricks = {
     name: "Broken Deku Stick (OoT)",
     tooltip: "Using different ways to prevent Link from putting away the Deku Stick after breaking it, the broken stick remains in Link's hands and can be used infinitely.",
     glitch: true,
+  },
+  GLITCH_OOT_SKULLTULA_ELEVATOR: {
+    game: 'oot',
+    name: "Skulltula Elevator (OoT)",
+    tooltip: "Skulltulas have a bobbing animation that uses a global timer. By repeatedly using well-timed pauses or Navi text boxes, the downwards part of the bobbing animation can be skipped, such that the Skulltula gradually moves upwards, allowing Link to roll or walk underneath."
+    glitch: true,
+    linkVideo: "https://www.youtube.com/watch?v=s-66puPn368&list=PLE8vRlR0R9U4"
   },
 };
 

--- a/packages/core/src/settings/tricks.ts
+++ b/packages/core/src/settings/tricks.ts
@@ -843,7 +843,7 @@ export const TRICKS: Tricks = {
   GLITCH_OOT_SKULLTULA_ELEVATOR: {
     game: 'oot',
     name: "Skulltula Elevator (OoT)",
-    tooltip: "Skulltulas have a bobbing animation that uses a global timer. By repeatedly using well-timed pauses or Navi text boxes, the downwards part of the bobbing animation can be skipped, such that the Skulltula gradually moves upwards, allowing Link to roll or walk underneath."
+    tooltip: "Skulltulas have a bobbing animation that uses a global timer. By repeatedly using well-timed pauses or Navi text boxes, the downwards part of the bobbing animation can be skipped, such that the Skulltula gradually moves upwards, allowing Link to roll or walk underneath.",
     glitch: true,
     linkVideo: "https://www.youtube.com/watch?v=s-66puPn368&list=PLE8vRlR0R9U4"
   },


### PR DESCRIPTION
(I closed the first PR to make it easier for me to solve merge conflicts)

I am very sorry how big this PR is. It just kept getting hideously complex.

I have not yet fully changed the changelog. I think I'll make a separate PR for that after merging.

Changes marked † in the change summary have details in the 'Change Detail' section

# Change Summary 

Consistently use the spelling "skulltula" in logic files. 
Numerous comments added to logic files, esp regarding alternate strats not accounted for yet (mostly within remit of this PR: skulltulas)

## New tricks/glitches
- Add Skulltula Elevator glitch (https://www.youtube.com/watch?v=s-66puPn368&list=PLOf1x45O7FsY)
- Trick for standing closely in front of the skulltula in forest MQ's first room (combines with skulltula elvator, hammer and bombchu as ways to clear the skulltula) (https://www.youtube.com/watch?v=zcr465LTwEU)

## macros_oot 
- Add temp_flag_event macro to handle situations where temp flags mean a single (ageless!) event is inappropriate
- † Add commented-out temp_flag_event_time_travel for temp_flag_event-type situations where time travel may not be available after moving to a new area
- Add is_forest_cleared macro
- Move icicle-related macros to a more appropriate section

- Add can_kill_skulltulas macro
- general changes to get_past_skulltulas_no_stone macro

## Kokiri Forest 
- logic now takes into account the skulltula that blocks adult link (mido tunnel to deku tree)

## Bottom of the Well 
- use get_past_skulltulas macro for initial skulltula
- add climb anywhere as a way past this skulltula

## Deku Tree 
- use get_past_skulltula macro for getting past the top-of-the-map skulltulas

## Forest Temple
- use get_past_skulltulas macro for first corridor's skulltula

## Thieves' Hideout
- fix logic's check for stone mask: `has_mask_stone` -> `can_use_mask_stone`. It now checks you can actually wear it as current age.

## Shadow Temple
- Scythe Silver Rupees - just some useful notes

## MQ Shadow
- Scythe Silver Rupees:
    - Account for the skulltulas that block the silver rupees
    - Add note about how vanilla SR collection logic flaw needs to be accounted for here
- Wind tunnels 
    - overhaul getting past the skulltula and past the pit logic. Skulltula elevator won't work without a way to avoid getting carried away by wind, so we can't use the can_get_past_skulltulas macro.
    - "hookshot_anywhere" was mentioned as a way to get through the wind tunnel. Just hookshot is enough in either direction.

## MQ Deku Tree 
- † The skulltula above the song of time block (basement) can be got around with nothing as both ages. Updated logic to reflect this.

## MQ Dodongo's Cavern 
- Consistently use "DC_MQ_" as the prefix for events rather than mixed use of "DC_MQ_" and "MQ_DC_"
- Staircase Room: properly account for the skulltulas by:
    - Splitting the upper area into two regions (Walkways, Upper Near Door), bounded by the skulltulas
    - Climb anywhere can be used to get around these skulltulas by climbing down onto the side of the walkway
    - split silver rupees between the two new regions as appropriate
- † Changes to the sequence of rooms: Vanilla Bomb Bag Room (lower) <-> before upper lizalfos <-> upper Lizalfos 
    - add additional region for the end of the corridor (just before the lizalfos fight)
    - overhaul events: remove some events that use temp flags. This avoids issues where logic expects the puzzle to still be solved if the player returns as a different age
    - locations/checks that relied on these events now check for the item requirements directly, even if that means crossing loading zones with lit deku sticks (which I assume door rando does not handle)
    - Add event, only triggerable when player has sot-age-change, that accounts for the ability to swap age (preserving the temp flag) and walk through the door to the larvae room (which may have age swap restricted in it e.g. Barinade boss room)
    - allow movement through invisible one-way collision (a web)
    - add event for destroying the mudwall at corridor end; this is a permanent flag

## MQ Forest Temple 
- First room skulltula overhauled.
    - add jump slash as a method (except with hammer)
    - remove spin slash as a method (jump slash covers this).
    - fixes raw bomb bag check - you need renewable bombs.
- † Movement from West garden to East garden via the high cooridor is blocked by 2 webs and a skulltula. The webs share a temp flag
    - split web destruction event into separate child and adult events.
    - use new temp_flag_event macro for this split
    - when climbing the vines, also check for the ability to either kill skulltula or use child+stone mask to get by it.
    - As a (probably too restrictive for door rando) failsafe, logic now understands that going through the door in the high alcove in the west garden now places link on the other side of the web, preventing him from going back through the door unless the web has been destroyed.
    - Sticks is now logical for destroying the web from the corridor, as long as you have access to the torch.
    - moving through the invisible one-way web now logical
    - moving through the visible one-way web is trick-gated (whereas previously it was merely web-destruction gated)
- Basement skulltula: logic now understands you can get past this with nothing

# Change Detail 

## MQ Deku Tree 
"The skulltula above the song of time block (basement) can be got around with nothing as both ages. Updated logic to reflect this."

Whilst the positioning to do this as child is precise, that positioning is both intuitive and mechcanially easy. You walk into the corner between the block and the wall (either side) and that makes sure you are as close to the wall as possible. Then climb the ledge without further ground movement else you might get knocked off. I can see a case for it being a trick, but I think that if something is intuitive and easy, it shouldn't be a trick.

As adult, it's much easier.

## MQ Dodongo 

MQ Dodongo: aside from adding new regions (neccesary because of the skultulas), I had to change how events worked in the upper east area (vanilla bomb bag room through to the lizalfos fight). This is because most of these events are temp flags. Because OoTMM's implementation of events is that they are collected by a single age and then usable by both ages, this meant logic was too permissive - in rare cases it would be possible for the generator to want you to trigger the event as one age and then come back as a different age to use that event, even though that's not possible. (Josh uses a lot of events in his MQ reworks, I reckon there's quite a few of these issues lurking).

An additional wrinkle was Song-of-time-age-change, which does not reset the temp flags when used. Without age change, you can only enter the _larvea room door_ if you can beat the 3-torch puzzle as that age (since if you leave the temple to change age, the door gets rebarred). If you have access to age change, you can enter the door as any age. This was implemented as an event (`DC_MQ_SOLVE_3-TORCH_PUZZLE_TIME_TRAVEL`) to share success in one age with the other.

The flags in this part of DC are as follows:
```
Things activated by 3-torch puzzle:
    the gold torch in that room                         --- TEMP, survives age change
    the door to larvae                                  --- TEMP, survives age change
the web torches act as one:
    if only one is lit, other goes out
    when both are lit, the gold torch lights
    survives room reload but not dungeon reload
    These and the gold torch they light are all:        --- TEMP, survives age change
the web                                                 --- PERM
the mud wall                                            --- PERM
```

## MQ Forest Temple 
The high web in forest temple MQ's East Courtyard (guarded by a skulltula) is also a temp flag. This flag survives age change. We have to solve this with a different implementation to Dodongo MQ because:
- Destroying one of the webs destroys the other web too (in a different room)
- There are multiple places (in logic) from which you can destroy the web
- I don't think there's a need to specially account for sot-age-change because either side of both webs is guaranteed a place you can use SoT age change.

So the implementation I chose here was to make the macro that checks event ages and double-up each event as a child/adult version.

Door rando may need to reconsider how these webs' shared flags work.

## temp_flag_event_time_travel macro 
I don't know if this macro is necessary. In Dodongo MQ I solved the temp flag + age change problem much more elegantly than this macro. Perhaps there are use-cases for the macro that I can't think of. At any rate, it's not used and therefore is commented out.

# Additional info 

Some skulltulas are too low for adult link to walk under using stone mask. But adult link can still roll under. Base logic now expects the player to know this.

I haven't touched logic for the skulltulas in deku basement (vanilla layout). You can get by both with nothing, but the one in water/spike room is a little awkward and not intuitive. The MQ one is pretty intuitive to get around.

There's a strange interaction with stone mask and skulltulas that block passageways. Running into them with stone mask often results in Link being shoved in a _random_ direction. This effectively means stone mask is enough to get past all skulltulas. Is this a glitch that should be patched?

There are many skulltulas that you can get past with nothing by getting a bit lucky and getting knocked past them. The only one I've made logical is forest temple MQ, because it's easy and semi-reliable. I think it could be a general purpose trick.

I think there needs to be a broader look at the interaction of events and temp flags, esp in Joshua's commits, since his style uses a lot of events. (And MQ seems to use a lot of temp flags)

Thanks for coming to my _series_ of TED talks.