### PR TITLE
Fix return to spawn when opposite age

### DIFF
--- a/packages/generator/include/combo/age.h
+++ b/packages/generator/include/combo/age.h
@@ -11,5 +11,6 @@ void Age_SetOot(PlayState* play, int age);
 void Age_SwapOot(PlayState* play);
 void Age_SetMm(PlayState* play, int age);
 void Age_SwapMm(PlayState* play);
-
+void Age_SetRawOot(PlayState* play, int age);
+void Age_SetRawMm(PlayState* play, int age);
 #endif

--- a/packages/generator/src/common/kaleido_scope.c
+++ b/packages/generator/src/common/kaleido_scope.c
@@ -104,11 +104,11 @@ static void KaleidoScope_GoBackToSpawn(PlayState* play, int age)
 {
     u32 entrance = gComboConfig.entrancesSpawns[age];
 
-    Age_SetOot(play, age);
-
 #if defined(GAME_MM)
-    /* Assume spawn is always an OoT spawn */
+    Age_SetRawOot(NULL, age);
     entrance |= MASK_FOREIGN_ENTRANCE;
+#else
+    Age_SetOot(play, age);
 #endif
 
     comboTransition(play, entrance);

--- a/packages/generator/src/mm/play/play.c
+++ b/packages/generator/src/mm/play/play.c
@@ -20,6 +20,8 @@
 #include <combo/time.h>
 #include <actors/Obj_Grass/Obj_Grass.h>
 
+#include "combo/age.h"
+
 /* Grass hooks */
 ObjGrass* gObjGrass;
 static u8 sNeedsScreenClear;
@@ -793,9 +795,10 @@ void Play_TransitionDone(PlayState* play)
 
     applyCustomEntrance(&entrance);
 
-    /* Check for foreign */
     if (entrance & MASK_FOREIGN_ENTRANCE)
     {
+        if (Config_Flag(CFG_MM_CROSS_AGE))
+            Age_SetRawMm(NULL, gOotSave.age);
         comboGameSwitch(play, entrance & ~MASK_FOREIGN_ENTRANCE);
     }
     else


### PR DESCRIPTION
Fix return to spawn crash from MM when you return to the spawn of the opposite current age. Now doesn't immediately assign the mm age which can potentially cause display list crash when wearing masks that resize with age. Instead oot age is immediately assigned and then mm age is assigned during the game swap to avoid those issues.